### PR TITLE
Replaced deprecated methods

### DIFF
--- a/lib/ottoman.js
+++ b/lib/ottoman.js
@@ -505,7 +505,7 @@ function _saveObj(obj, key, doc, callback) {
         return doNext();
       }
 
-      obj.$.bucket.add(refDocAdds[curIdx], key, function(e) {
+      obj.$.bucket.insert(refDocAdds[curIdx], key, function(e) {
         if (e) {
           // Begin Rollback
           curIdx--;
@@ -528,7 +528,7 @@ function _saveObj(obj, key, doc, callback) {
       });
     } else if (stage === 2) {
       obj.$initial = doc;
-      obj.$.bucket.set(key, doc, {cas: obj.$cas}, function(){
+      obj.$.bucket.upsert(key, doc, {cas: obj.$cas}, function(){
         stage = 3;
         return doNext();
       });


### PR DESCRIPTION
Bucket.set and Bucket.add in couchbase (https://github.com/couchbase/couchnode) have been replaced with Bucket.upsert and Bucket.insert (respectively)