### PR TITLE
Removed eval usage in the ottoman build model function.

### DIFF
--- a/lib/ottoman.js
+++ b/lib/ottoman.js
@@ -590,11 +590,11 @@ Ottoman.prototype._buildModel = function(name, schemaDef, options) {
 
   var schema = this._createSchema(name, schemaDef, options);
 
-  var model = null;
-  eval( // jshint -W061
-      'model = function ' + name + '() {\n' +
-      '    ModelInstance.apply(this, arguments);\n' +
-      '}\n');
+  var modelWrapper = {};
+  var model = modelWrapper[name] = function() {
+      ModelInstance.apply(this, arguments);
+  };
+
   util.inherits(model, ModelInstance);
 
   model.schema = schema;


### PR DESCRIPTION
Eval is slower and generally shouldn't be used.  This just wraps the model in an object which can have names dynamically created then assigns it back to model.