### PR TITLE
Fix removing existing refdoc from another document on updating document.

### DIFF
--- a/lib/modelinstance.js
+++ b/lib/modelinstance.js
@@ -352,7 +352,7 @@ function _tryAddRefs(bucket, keys, refKey, callback) {
     bucket.store(key, refKey, null, function(err) {
       if (err) {
         errs.push(err);
-        --i;
+        i-=2;
         stepBackward();
         return;
       }


### PR DESCRIPTION
If you are trying to update indexed property with duplicate value, ottoman removes existing refdoc from another document.