### PR TITLE
Add key delimiter

### DIFF
--- a/lib/modelinstance.js
+++ b/lib/modelinstance.js
@@ -148,14 +148,14 @@ function _modelKey(mdl) {
 ModelInstance.prototype.id = function() {
   var $ = this.$;
   if (!$.loaded) {
-    var keyPrefix = $.schema.namePath() + '|';
+    var keyPrefix = $.schema.namePath() + $.schema.keyDelimiter;
     if ($.key.substr(0, keyPrefix.length) !== keyPrefix) {
       throw new Error('The key of this object appears incorrect.');
     }
     return $.key.substr(keyPrefix.length);
   }
   var myId = $.schema.fieldVal(this, this.$.schema.idField);
-  var newKey = $.schema.namePath() + '|' + myId;
+  var newKey = $.schema.namePath() + $.schema.keyDelimiter + myId;
   if ($.key !== null) {
     if ($.key !== newKey) {
       throw new Error('The Key of the object has changed!');
@@ -669,7 +669,7 @@ ModelInstance.refByKey = function(key) {
  * @returns {ModelInstance}
  */
 ModelInstance.ref = function(id) {
-  return this.refByKey(this.schema.namePath() + '|' + id);
+  return this.refByKey(this.schema.namePath() + $.schema.keyDelimiter + id);
 };
 
 /**

--- a/lib/ottoman.js
+++ b/lib/ottoman.js
@@ -313,6 +313,9 @@ Ottoman.prototype._createSchema = function(name, schemaDef, options) {
     schema.store = this.store;
   }
 
+  if (options.keyDelimiter) {
+    schema.keyDelimiter = options.keyDelimiter;
+  }
   return schema;
 };
 
@@ -572,7 +575,7 @@ Ottoman.prototype._findModels = function(model, filter, options, callback) {
         callback(null, results);
       }
     }
-    
+
     var loadArgs = [handler];
     if (options.load) {
       loadArgs = options.load.concat(loadArgs);

--- a/lib/ottoman.js
+++ b/lib/ottoman.js
@@ -315,7 +315,10 @@ Ottoman.prototype._createSchema = function(name, schemaDef, options) {
 
   if (options.keyDelimiter) {
     schema.keyDelimiter = options.keyDelimiter;
+  }else{
+    schema.keyDelimiter = '|';
   }
+
   return schema;
 };
 

--- a/lib/schema.js
+++ b/lib/schema.js
@@ -8,6 +8,7 @@ var SearchConsistency = StoreAdapter.SearchConsistency;
 function SchemaOptions() {
   this.id = '_id';
   this.store = null;
+  this.keyDelimiter = '|';
 }
 
 function FieldDef() {
@@ -544,7 +545,7 @@ Schema.prototype.execPreHandlers = function(event, mdlInst, callback) {
     callback(null);
     return;
   }
-  
+
   var preHandlers = this.preHandlers[event];
   var i = 0;
   var doNext = function _doNextPreHandler() {


### PR DESCRIPTION
Enable delimiter configuration of key document.

```
var BaseDemo = ottoman.model('BaseDemo',  {
    store: 'string',
    prefix:'string'
}, {
    index: {
        findByStoreAndPrefix:{
            by: ['store','prefix'],
            type: 'n1ql'
        }
    },
    keyDelimiter:':'
});

```

By default use '|'

**before**
BaseDemo|8a9941ae-82d9-406e-8d13-688b47233d5a
**After**
BaseDemo:8a9941ae-82d9-406e-8d13-688b47233d5a