### PR TITLE
fix for n1ql index creation issue reported https://forums.couchbase.c…

### DIFF
--- a/lib/cbstoreadapter.js
+++ b/lib/cbstoreadapter.js
@@ -322,84 +322,158 @@ function _ottopathToN1qlPath(path) {
  * @ignore
  */
 CbStoreAdapter.prototype._ensureGsiIndices = function(callback) {
-  var queries = [];
+    var queries = [];
+    var indexes = [];
 
-  // Primary GSI Index First!
-  queries.push(
-      'CREATE PRIMARY INDEX ON `' + this.bucket._name + '` USING GSI');
+    // Build a list of indexes to create.
+    // General strategy for this function is to first issue a 
+    // CREATE PRIMARY INDEX
+    // Then do a number of "CREATE INDEX" statements, deferring build.
+    // Finally, do a "BUILD INDEX" statement to catch up on all of the 
+    // deferreds.
+    for (var i in this.gsis) {
+        if (this.gsis.hasOwnProperty(i)) {
+            var gsi = this.gsis[i];
 
-  // Additional indices here
-  for (var i in this.gsis) {
-    if (this.gsis.hasOwnProperty(i)) {
-      var gsi = this.gsis[i];
+            var indexName = i.replace('$', '__').replace('[*]', '-ALL');
+            var fieldNames = [];
+            for (var j = 0; j < gsi.fields.length; ++j) {
+                try {
+                    var path = ottopath.parse(gsi.fields[j]);
+                    var wildCardAt = -1;
+                    for (var k = 0; k < path.length; ++k) {
+                        if (path[k].operation === 'subscript' &&
+                            path[k].expression.type === 'wildcard') {
+                            if (wildCardAt !== -1) {
+                                throw new Error('Cannot create an index'+
+                                    ' with more than ' +
+                                    'one wildcard in path.');
+                            }
+                            wildCardAt = k;
+                        }
+                    }
 
-      var indexName = i.replace('$', '__').replace('[*]', '-ALL');
-      var fieldNames = [];
-      for (var j = 0; j < gsi.fields.length; ++j) {
-        try {
-          var path = ottopath.parse(gsi.fields[j]);
-          var wildCardAt = -1;
-          for (var k = 0; k < path.length; ++k) {
-            if (path[k].operation === 'subscript' &&
-                path[k].expression.type === 'wildcard') {
-              if (wildCardAt !== -1) {
-                throw new Error('Cannot create an index with more than ' +
-                    'one wildcard in path.');
-              }
-              wildCardAt = k;
+                    if (wildCardAt === -1) {
+                        fieldNames.push(_ottopathToN1qlPath(path));
+                    } else {
+                        var pathBefore = path.slice(0, wildCardAt);
+                        var pathAfter = path.slice(wildCardAt + 1);
+
+                        var objTarget = _ottopathToN1qlPath(pathAfter);
+                        if (objTarget !== '') {
+                            objTarget = 'v.' + objTarget;
+                        } else {
+                            objTarget = 'v';
+                        }
+
+                        var arrTarget = _ottopathToN1qlPath(pathBefore);
+
+                        fieldNames.push('DISTINCT ARRAY ' + objTarget +
+                            ' FOR v IN ' + arrTarget + ' END');
+                    }
+                } catch (e) {
+                    callback(e);
+                    return;
+                }
             }
-          }
-
-          if (wildCardAt === -1) {
-            fieldNames.push(_ottopathToN1qlPath(path));
-          } else {
-            var pathBefore = path.slice(0, wildCardAt);
-            var pathAfter = path.slice(wildCardAt + 1);
-
-            var objTarget = _ottopathToN1qlPath(pathAfter);
-            if (objTarget !== '') {
-              objTarget = 'v.' + objTarget;
-            } else {
-              objTarget = 'v';
-            }
-
-            var arrTarget = _ottopathToN1qlPath(pathBefore);
-
-            fieldNames.push('DISTINCT ARRAY ' + objTarget +
-                ' FOR v IN ' + arrTarget + ' END');
-          }
-        } catch(e) {
-          callback(e);
-          return;
+            
+            queries.push(
+                'CREATE INDEX `' + indexName + '` ' +
+                'ON `' + this.bucket._name + '`(' + 
+                fieldNames.join(',') + 
+                ') ' +
+                'WHERE _type="' + gsi.modelName + '" ' +
+                'USING GSI WITH {\"defer_build\": true}');
+            
+            // Keep track of all indexes we are creating, so we can
+            // build them later.
+            indexes.push(indexName);
         }
-      }
-      queries.push(
-          'CREATE INDEX `' + indexName + '` ' +
-          'ON `' + this.bucket._name + '`(' + fieldNames.join(',') + ') ' +
-          'WHERE _type="' + gsi.modelName + '" ' +
-          'USING GSI');
-    }
-  }
-
-  // Run the queries
-  var proced = 0;
-  function handler(err) {
-    if (err) {
-      proced = queries.length;
-      callback(err);
-      return;
     }
 
-    proced++;
-    if (proced === queries.length) {
-      callback(null);
-      return;
+    // Set reference so inner callbacks can use this.
+    var storeAdapter = this;
+
+    var proced = 0;
+    
+    // Takes a query as an argument, returns a handler.
+    // Previous version would indicate failure, without indicating
+    // which n1ql query failed.
+    function indexCreateCompleteHandler(query) {
+        return function(err, rows, meta) {
+            if (err) {
+                console.error('Failed to create index indicated via ' + 
+                              query + ' -- ' + err);
+                proced = queries.length;
+                callback(err);
+                return;
+            }
+
+            proced++;
+            if (proced === queries.length) {
+                // At this point, all index creation worked.
+                // Final step (which can only be done once all indexes 
+                // have been created) is to issue BUILD INDEX on all of 
+                // them.
+                // If you do this with the rest of the batch, this query 
+                // will run before all indexes are created, and it will 
+                // die with an error that a referenced index doesn't 
+                // exist.
+                var buildQuery =
+                    'BUILD INDEX ON `' + storeAdapter.bucket._name + '`(' +
+                    indexes.map(function(idx) {
+                        return '`' + idx + '`';
+                    }).join(',') +
+                    ') USING GSI';
+
+                // console.log("Running final build.... " + 
+                //             buildIndexQuery);
+                var n1ql = couchbase.N1qlQuery.fromString(buildQuery);
+                storeAdapter.bucket.query(n1ql,
+                    function(err, rows, meta) {
+                        // console.log('BUILD INDEXES: ' + buildIndexQuery + 
+                        //     ' err=' + err +
+                        //     ' rows=' + JSON.stringify(rows) +
+                        //     ' meta=' + JSON.stringify(meta));
+
+                        if (err) {
+                            return callback(err);
+                        }
+
+                        return callback(null);
+                    });
+
+                return;
+            }
+        };
     }
-  }
-  for (var l = 0; l < queries.length; ++l) {
-    var query = queries[l];
-    this.bucket.query(couchbase.N1qlQuery.fromString(query), handler);
-  }
+
+    /*
+     * After create primary index, this loops through and runs all
+     * of the CREATE INDEX statements.
+     */
+    var runSubsequentIndexQueries = function(err, rows, meta) {
+        // Did creating the primary index work?
+        // console.log("CREATE PRIMARY INDEX: err=" + err + 
+        //             " rows=" + JSON.stringify(rows) + 
+        //             " meta=" + JSON.stringify(meta));
+        if (err) { return callback(err); }
+
+        // If it did, run all of the dependent index creation.
+        for (var l = 0; l < queries.length; ++l) {
+            var query = queries[l];
+
+            storeAdapter.bucket.query(couchbase.N1qlQuery.fromString(query),
+                indexCreateCompleteHandler(query));
+        }
+    };
+
+    // Kick the whole thing off by creating primary index
+    var primaryIndexFirst = 'CREATE PRIMARY INDEX ON `' +
+        this.bucket._name + '` USING GSI';
+    this.bucket.query(couchbase.N1qlQuery.fromString(primaryIndexFirst),
+        runSubsequentIndexQueries);
+    return;
 };
 
 /**


### PR DESCRIPTION
Original bug report: https://forums.couchbase.com/t/ottoman-n1ql-index-building-issue/7532/2

Resolution - n1ql indices are created now with `{"defer_build": true}`, followed by a `BUILD INDEX` query.

The original `CREATE DEFAULT INDEX` query is separated from the others, and is monitored for success before the later `CREATE INDEX` queries are executed.

Tested and working well on our code, which includes about a dozen Ottoman models with a total of about 30 n1ql indexes.