### PR TITLE
Allows fields with a refdoc specified to be undefined

### DIFF
--- a/lib/mockstoreadapter.js
+++ b/lib/mockstoreadapter.js
@@ -4,7 +4,7 @@ var util = require('util');
 var StoreAdapter = require('./storeadapter');
 
 var NOT_FOUND_ERR = new Error('Key was not found.');
-var ALREADY_EXISTS_ERR = new Error('Key already exited.');
+var ALREADY_EXISTS_ERR = new Error('Key already exists.');
 var CAS_MISMATCH_ERR = new Error('CAS does not match.');
 
 function makeCas() {

--- a/lib/schema.js
+++ b/lib/schema.js
@@ -214,9 +214,17 @@ Schema.prototype.refKeys = function(mdl) {
     var refIndex = refIndices[i];
     var refValues = [];
     for (var j = 0; j < refIndex.fields.length; ++j) {
-      refValues.push(this.fieldVal(mdl, refIndex.fields[j]));
+      var value = this.fieldVal(mdl, refIndex.fields[j]);
+      //Prevents refdoc keys from having "undefined"
+      if(value){
+        refValues.push(value);
+      }
     }
-    refKeys.push(this.refKey(refIndex.fields, refValues));
+    //only if there were defined values should the refkey go through
+    // this allows any number of null values to be stored without colliding
+    if(refValues.length > 0){
+      refKeys.push(this.refKey(refIndex.fields, refValues));
+    }
   }
   return refKeys;
 };

--- a/test/indexes.test.js
+++ b/test/indexes.test.js
@@ -106,6 +106,44 @@ describe('Model Indexes', function() {
       });
     });
   });
+  it('should be ok to have two refdocs both undefined', function(done) {
+    var modelId = H.uniqueId('model');
+
+    var TestMdl = ottoman.model(modelId, {
+      name: 'string',
+      company: 'string'
+    }, {
+      index: {
+        findByName: {
+          type: 'refdoc',
+          by: 'name'
+        },
+        findByCompany: {
+          type: 'refdoc',
+          by: 'company'
+        }
+      }
+    });
+
+    ottoman.ensureIndices(function(err) {
+      assert.isNull(err);
+
+      var x = new TestMdl();
+      x.name = 'Frank';
+      var y = new TestMdl();
+      y.name = 'George';
+
+      x.save(function(err) {
+        assert.isNull(err);
+
+        y.save(function(err) {
+          assert.isNull(err);
+          done();
+        });
+      });
+    });
+  });
+
 
   it('should succeed with a previously changed refdoc key', function(done) {
     var modelId = H.uniqueId('model');


### PR DESCRIPTION
So if you create a field with a refdoc index, you must add only unique values. In the case of undefined values, a refdoc key with "Model|undefined" was added. In this change, these undefined values are simply ignored. This includes a unit test that allows several documents to be added without colliding on this undefined value. 

I also noticed a silly mock grammatical error in there. Hope that's ok. 