### PR TITLE
allow undefined fields in refdoc indexes 

### DIFF
--- a/lib/mockstoreadapter.js
+++ b/lib/mockstoreadapter.js
@@ -4,7 +4,7 @@ var util = require('util');
 var StoreAdapter = require('./storeadapter');
 
 var NOT_FOUND_ERR = new Error('Key was not found.');
-var ALREADY_EXISTS_ERR = new Error('Key already exited.');
+var ALREADY_EXISTS_ERR = new Error('Key already exists.');
 var CAS_MISMATCH_ERR = new Error('CAS does not match.');
 
 function makeCas() {

--- a/lib/schema.js
+++ b/lib/schema.js
@@ -214,9 +214,19 @@ Schema.prototype.refKeys = function(mdl) {
     var refIndex = refIndices[i];
     var refValues = [];
     for (var j = 0; j < refIndex.fields.length; ++j) {
-      refValues.push(this.fieldVal(mdl, refIndex.fields[j]));
+      var value = this.fieldVal(mdl, refIndex.fields[j]);
+      //Prevents refdoc keys from having "undefined" values
+      if(value === undefined ){
+        refValues = [];
+        break;
+      }
+      refValues.push(value);
     }
-    refKeys.push(this.refKey(refIndex.fields, refValues));
+    //only if there were defined values should the refkey go through
+    // this allows any number of null values to be stored without colliding
+    if(refValues.length > 0){
+      refKeys.push(this.refKey(refIndex.fields, refValues));
+    }
   }
   return refKeys;
 };

--- a/test/indexes.test.js
+++ b/test/indexes.test.js
@@ -107,6 +107,80 @@ describe('Model Indexes', function() {
     });
   });
 
+  it('should allow two paths with the same name when undefined', function(done) {
+    var modelId = H.uniqueId('model');
+
+    var TestMdl = ottoman.model(modelId, {
+      name: 'string',
+      company: 'string'
+    }, {
+      index: {
+        findByNameAndCompany: {
+          type: 'refdoc',
+          by: ['name', 'company']
+        }
+      }
+    });
+
+    ottoman.ensureIndices(function(err) {
+      assert.isNull(err);
+
+      var x = new TestMdl();
+      x.name = 'Frank';
+      var y = new TestMdl();
+      y.company = 'Frank';
+
+      x.save(function(err) {
+        assert.isNull(err);
+
+        y.save(function(err) {
+          assert.isNull(err);
+          done();
+        });
+      });
+    });
+  });
+
+
+  it('should be ok to have two refdocs both undefined', function(done) {
+    var modelId = H.uniqueId('model');
+
+    var TestMdl = ottoman.model(modelId, {
+      name: 'string',
+      company: 'string'
+    }, {
+      index: {
+        findByName: {
+          type: 'refdoc',
+          by: 'name'
+        },
+        findByCompany: {
+          type: 'refdoc',
+          by: 'company'
+        }
+      }
+    });
+
+    ottoman.ensureIndices(function(err) {
+      assert.isNull(err);
+
+      var x = new TestMdl();
+      x.name = 'Frank';
+      var y = new TestMdl();
+      y.name = 'George';
+
+      x.save(function(err) {
+        assert.isNull(err);
+
+        y.save(function(err) {
+          assert.isNull(err);
+          done();
+        });
+      });
+    });
+  });
+
+
   it('should succeed with a previously changed refdoc key', function(done) {
     var modelId = H.uniqueId('model');
     var TestMdl = ottoman.model(modelId, {


### PR DESCRIPTION
This patch will simply not create a refdoc index if none of the values are defined. This prevents ottoman from storing "Document|undefined" refdoc keys. If any values are defined, then the index will be created and must be unique. 
Two test cases were added for this, one in which the value is undefined for two otherwise separate documents. The other checks that you can create a refdoc index across multiple fields and that these indices will not collide if they contain the same data in different fields. 