### PR TITLE
Fix falsy default values

### DIFF
--- a/lib/ottoman.js
+++ b/lib/ottoman.js
@@ -250,7 +250,7 @@ Ottoman.prototype._makeField = function(name, fieldDef) {
       }
       field.default = autofns.uuid;
     }
-  } else if (fieldDef.default) {
+  } else if (fieldDef.default !== undefined) {
     if (field.type === Schema.DateType && fieldDef.default === Date.now) {
       field.default = function() { return new Date(); };
     } else {


### PR DESCRIPTION
If a default is set to a falsy value was not taken in account resulting
in undefined. For example {default: 0} was not set on model creation.
This fix this case