### PR TITLE
filters should be able to handle boolean

### DIFF
--- a/lib/cbstoreadapter.js
+++ b/lib/cbstoreadapter.js
@@ -670,7 +670,7 @@ function _buildFilterExprs(filters, expressions, root) {
       if (filters[i] instanceof Object) {
         _buildFilterExprs(filters[i], expressions, ident + '.');
       } else {
-        if (typeof filters[i] === 'number') {
+        if (typeof filters[i] === 'number' || typeof filters[i] === 'boolean') {
           expressions.push(ident + '=' + filters[i]);
         } else if (typeof filters[i] === 'string') {
           expressions.push(


### PR DESCRIPTION
So this is fairly self explanatory.. Right now if you try to use an n1ql find-by function on a boolean field you get an error when you try to query on that field because it doesn't check for a boolean and throws the "invalid filter type" error. Do let me know if there's an important reason that I've missed for leaving booleans out of this. Perhaps a better todo here would be to eventually check the schema type instead of the datatype coming from the function call. 