### PR TITLE
filters should handle boolean types

### DIFF
--- a/lib/cbstoreadapter.js
+++ b/lib/cbstoreadapter.js
@@ -673,7 +673,7 @@ function _buildFilterExprs(filters, expressions, root) {
       if (filters[i] instanceof Object) {
         _buildFilterExprs(filters[i], expressions, ident + '.');
       } else {
-        if (typeof filters[i] === 'number') {
+        if (typeof filters[i] === 'number' || typeof filters[i] === 'boolean') {
           expressions.push(ident + '=' + filters[i]);
         } else if (typeof filters[i] === 'string') {
           expressions.push(


### PR DESCRIPTION
This commit simply makes it possible for the queries that are constructed for n1ql indices to work if they are a boolean value. Someday it might be worth refactoring such that these data types are recognized from the schema instead of the function call but this works for now. 