### PR TITLE
Fix Ottoman Event Hooks

### DIFF
--- a/lib/cbstoreadapter.js
+++ b/lib/cbstoreadapter.js
@@ -648,7 +648,7 @@ CbStoreAdapter.prototype.searchIndex =
  */
 function _buildFilterExprs(filters, expressions, root) {
   var SPECIAL_KEYS = ['$exists','$contains'];
-
+  var BOOLEAN = ['or', 'and'];
   if (!root) {
     root = '';
   }
@@ -670,7 +670,26 @@ function _buildFilterExprs(filters, expressions, root) {
         expressions.push('ANY x IN ' + ident + ' SATISFIES ' +
             subexprs.join(' AND ') + ' END');
       }
-      if (filters[i] instanceof Object) {
+      if(BOOLEAN.indexOf(i.toLowerCase()) !== -1) {
+	      var booleanExprs = [];
+        
+	      for(var j in filters[i]) {
+          if(filters[i].hasOwnProperty(j)) { 
+            _buildFilterExprs(filters[i][j], booleanExprs, '');
+          } 
+        }
+                
+	      expressions.push('(' + booleanExprs.join(' ' + 
+           i.toUpperCase() + ' ') + ')');
+      } else if(i.toLowerCase() === 'not') {
+        var notExprs = [];
+        for(var z in filters[i]) {
+          if(filters[i].hasOwnProperty(z)) {
+             _buildFilterExprs(filters[i][z], notExprs, '');
+          }
+        } 	
+	      expressions.push('NOT (' + notExprs.join(' AND ') + ')');
+      } else if (filters[i] instanceof Object) {
         _buildFilterExprs(filters[i], expressions, ident + '.');
       } else {
         if (typeof filters[i] === 'number' || typeof filters[i] === 'boolean') {

--- a/lib/cbstoreadapter.js
+++ b/lib/cbstoreadapter.js
@@ -670,7 +670,7 @@ function _buildFilterExprs(filters, expressions, root) {
       if (filters[i] instanceof Object) {
         _buildFilterExprs(filters[i], expressions, ident + '.');
       } else {
-        if (typeof filters[i] === 'number') {
+        if (typeof filters[i] === 'number' || typeof filters[i] === 'boolean') {
           expressions.push(ident + '=' + filters[i]);
         } else if (typeof filters[i] === 'string') {
           expressions.push(

--- a/lib/modelinstance.js
+++ b/lib/modelinstance.js
@@ -174,24 +174,26 @@ function _findField(fields, name) {
   return null;
 }
 
-function _encodeValue(context, type, value, forceTyping) {
+function _encodeValue(context, type, value, forceTyping,f) {
   if (context.isModel(type)) {
     if (!(value instanceof type)) {
-      throw new Error('Expected type to be a `' + type.name + '`');
+      throw new Error('Expected ' + f.name +' type to be a `' + 
+          type.name + '`');
     }
     return value._toCoo(type.name, forceTyping);
   } else if (type instanceof Schema.ListField) {
     if (!Array.isArray(value)) {
-      throw new Error('Expected type to be an array.');
+      throw new Error('Expected ' +f.name + ' type to be an array.');
     }
     var outArr = [];
     for (var i = 0; i < value.length; ++i) {
-      outArr[i] = _encodeValue(context, type.type, value[i], forceTyping);
+      outArr[i] = _encodeValue(context, type.type, value[i], forceTyping,f);
     }
     return outArr;
   } else if (type instanceof Schema.FieldGroup) {
     if (!(value instanceof Object)) {
-      throw new Error('Expected object type but got non-object.');
+      throw new Error('Expected ' + f.name + 
+          ' object type but got non-object.');
     }
     var outObj = {};
     for (var j in value) {
@@ -201,13 +203,14 @@ function _encodeValue(context, type, value, forceTyping) {
         if (!field) {
           throw new Error('Cannot find field data for property `' + j + '`.');
         }
-        outObj[j] = _encodeValue(context, field.type, value[j], forceTyping);
+        outObj[j] = _encodeValue(context, field.type, value[j], 
+            forceTyping, field);
       }
     }
     return outObj;
   } else if (type instanceof Schema.ModelRef) {
     if (!(value instanceof ModelInstance)) {
-      throw new Error('Expected type to be a ModelInstance.');
+      throw new Error('Expected ' + f.name + ' type to be a ModelInstance.');
     }
     if (type.name !== value.$.schema.name) {
       throw new Error('Expected type to be `' +
@@ -219,9 +222,15 @@ function _encodeValue(context, type, value, forceTyping) {
     };
   } else if (type === Schema.DateType) {
     if (!(value instanceof Date)) {
-      throw new Error('Expected type to be a Date.');
+      // throw new Error('Expected ' + f.name + ' type to be a Date.');
+      value = new Date(value);
     }
-    return value.toISOString();
+    try { 
+       return value.toISOString();
+    } catch(err) {
+	console.error('Invalid date ' + value + ' in ' + f.name);
+	return null;
+    }
   } else if (type === Schema.MixedType) {
     if (value instanceof ModelInstance) {
       return value._toCoo(type.name, forceTyping);
@@ -235,7 +244,8 @@ function _encodeValue(context, type, value, forceTyping) {
     }
   } else {
     if (value instanceof Object) {
-      throw new Error('Expected non-object type but got object.');
+      throw new Error('Expected ' + f.name + ' non-object type ' + 
+		       JSON.stringify(type) + ' but got object.');
     }
     return value;
   }
@@ -264,7 +274,8 @@ ModelInstance.prototype._toCoo = function(refType, forceTyping) {
     if (this.hasOwnProperty(i)) {
       var field = $.schema.field(i);
       objOut[i] =
-          _encodeValue($.schema.context, field.type, this[i], forceTyping);
+          _encodeValue($.schema.context, field.type, this[i], 
+              forceTyping, field);
     }
   }
   return objOut;

--- a/lib/modelinstance.js
+++ b/lib/modelinstance.js
@@ -516,7 +516,7 @@ ModelInstance.loadAll = function(items, callback) {
  * @param {...string=} paths Paths to sub-model-instances to load.
  * @param {Function} callback
  */
-ModelInstance.prototype.load = function(callback) {
+ModelInstance.prototype.load = function(callback) {  
   var loadItems = [];
   var finalCallback = function() { };
   for (var i = 0; i < arguments.length; ++i) {
@@ -568,20 +568,25 @@ ModelInstance.prototype.load = function(callback) {
   }
 
   if (!this.loaded()) {
-    var key = _modelKey(self);
-    $.schema.store.get(key, function(err, data, cas) {
-      if (err) {
-        finalCallback(err);
-        return;
-      }
+      $.schema.execPreHandlers('load', self, function () {
+          var key = _modelKey(self);
+          $.schema.store.get(key, function (err, data, cas) {
+              if (err) {
+                  finalCallback(err);
+                  return;
+              }
 
-      var md = new ModelData();
-      md.key = $.key;
-      md.data = data;
-      md.cas = cas;
-      ModelInstance.applyData(self, md);
-      loadSubItem();
-    });
+              var md = new ModelData();
+              md.key = $.key;
+              md.data = data;
+              md.cas = cas;
+              ModelInstance.applyData(self, md);
+              loadSubItem();
+              
+              var deadEnd = function () { };
+              $.schema.execPostHandlers('load', self, deadEnd);
+          });                   
+      });
   } else {
     loadSubItem();
   }
@@ -594,6 +599,7 @@ ModelInstance.prototype.load = function(callback) {
  */
 ModelInstance.prototype.remove = function(callback) {
   var $ = this.$;
+  var self = this;
   var key = _modelKey(this);
 
   // TODO: Fix this not to use refKeys
@@ -607,24 +613,33 @@ ModelInstance.prototype.remove = function(callback) {
     return;
   }
 
-  // Remove the document itself first, then remove any
-  //  reference keys.  This order is important as if the
-  //  reference keys fail to get removed, the references
-  //  will still point to nothing.
-  $.schema.store.remove(key, $.cas, function(err) {
-    if (err) {
-      callback(err);
-      return;
-    }
+  $.schema.execPreHandlers('remove', self, function () {
+      // Remove the document itself first, then remove any
+      //  reference keys.  This order is important as if the
+      //  reference keys fail to get removed, the references
+      //  will still point to nothing.
+      $.schema.store.remove(key, $.cas, function (err) {
+          if (err) {
+              callback(err);
+              return;
+          }
 
-    _tryRemoveRefs($.schema.store, $.refKeys, function(err) {
-      if (err) {
-        callback(err);
-        return;
-      }
+          _tryRemoveRefs($.schema.store, $.refKeys, function (err) {
+              if (err) {
+                  callback(err);
+                  return;
+              }
 
-      callback(null);
-    });
+              var deadEnd = function (err) {
+                  if (err) {
+                      console.log('Ottoman post-save handler returned ' + err);
+                  }
+              };
+
+              $.schema.execPostHandlers('remove', self, deadEnd);
+              callback(null);
+          });
+      });
   });
 };
 
@@ -707,9 +722,12 @@ ModelInstance.ref = function(id) {
 
 /**
  * Specify a handler to be invoked prior to a particular event for this
- * ModelInstance.
+ * ModelInstance.  The handler will always be called with two arguments:
+ * the model instance, and a callback function that the handler should 
+ * call to continue processing.  If a pre handler calls the provided 
+ * callback with an error, the event will not continue.
  *
- * @param {"validate"|"save"|"load"} event
+ * @param {"validate"|"save"|"load"|"remove"} event
  * @param {Function} handler
  */
 ModelInstance.pre = function(event, handler) {
@@ -718,9 +736,10 @@ ModelInstance.pre = function(event, handler) {
 
 /**
  * Specify a function to be invoked following a particular event on this
- * ModelInstance.
+ * ModelInstance.  The handler will always be called with two arguments:
+ * the model instance, and a callback.   
  *
- * @param {"validate"|"save"|"load"} event
+ * @param {"validate"|"save"|"load"|"remove"} event
  * @param {Function} fn
  */
 ModelInstance.post = function(event, fn) {

--- a/lib/ottoman.js
+++ b/lib/ottoman.js
@@ -514,6 +514,13 @@ Ottoman.prototype._countModels = function(model, filter, callback) {
   });
 };
 
+/**
+ * Normalizes a filter structure by replacing ModelInstance
+ * objects with a $ref that can be passed through to n1ql.
+ * @param a filter object, such as what is passed to _findModels
+ * @private
+ * @ignore
+ */
 Ottoman.prototype._normFilter = function(filter) {
   var out = {};
   for (var i in filter) {

--- a/lib/schema.js
+++ b/lib/schema.js
@@ -636,10 +636,14 @@ Schema.prototype.execPreHandlers = function(event, mdlInst, callback) {
     callback(null);
     return;
   }
-  
+
   var preHandlers = this.preHandlers[event];
   var i = 0;
-  var doNext = function _doNextPreHandler() {
+  var doNext = function _doNextPreHandler(err) {
+    // If any one of the pre-handlers fails, fail the whole thing.
+    // This allows people to plug in additional validation.
+    if(err) { return callback(err); }
+
     if (i === preHandlers.length) {
       callback(null);
       return;
@@ -647,7 +651,8 @@ Schema.prototype.execPreHandlers = function(event, mdlInst, callback) {
 
     var curI = i;
     i++;
-    preHandlers[curI].call(mdlInst, doNext);
+
+    preHandlers[curI].call(mdlInst, mdlInst, doNext);
   };
   doNext();
 };
@@ -661,15 +666,22 @@ Schema.prototype.execPostHandlers = function(event, mdlInst, callback) {
   try {
     var postHandlers = this.postHandlers[event];
     for (var i = 0; i < postHandlers.length; ++i) {
-      postHandlers[i](mdlInst);
+      // After an action has taken place we don't really
+      // need this callback, but we will add it for consistency
+      // in the API: post handlers should expect to always get
+      // 2 arguments, mdlInst and callback.
+      var doNext = function () { };
+
+      postHandlers[i].call(mdlInst, mdlInst, doNext);
     }
+
     callback(null);
   } catch (e) {
     callback(e);
   }
 };
 
-var supportedEvents = ['validate', 'save', 'remove'];
+var supportedEvents = ['validate', 'save', 'load', 'remove'];
 
 Schema.prototype.addPreHandler = function(event, callback) {
   if (supportedEvents.indexOf(event) === -1) {

--- a/test/hooks.test.js
+++ b/test/hooks.test.js
@@ -1,0 +1,85 @@
+var chai = require('chai');
+var expect = chai.expect;
+var H = require('./harness');
+var ottoman = H.lib;
+
+/*
+ * Tests to ensure that pre/post hooks are executed as promised by
+ * ottoman.
+ *
+ * Concept here is to take a simple model through the entire lifecycle
+ * of creation and deletion and check that a spy function was called.
+ */
+describe('Model hooks', function () {
+  this.timeout(10000);
+
+  var milestones = ['pre', 'post'];
+  var events = ['validate', 'save', 'load', 'remove'];
+
+  var testMilestoneEvent = function (milestone, event) {
+    it('should trigger callbacks on ' + milestone + '-' + event, function (done) {
+      var called = false;
+
+      var callMeOnEvent = function (mdlInst, next) {
+        // console.log('I got called: ' + milestone + ' ' + event);
+        called = true;
+        next();
+      };
+
+      var modelId = H.uniqueId('model');
+      var TestMdl = ottoman.model(modelId, {
+        name: 'string'
+      }, {
+          index: {
+            findByName: {
+              type: 'refdoc',
+              by: 'name',
+              consistency: ottoman.Consistency.GLOBAL
+            }
+          }
+      });
+
+      var x = new TestMdl();
+      var searchStr = 'Hello ' + Math.random();
+      x.name = searchStr;
+
+      // Set hanlder...
+      TestMdl[milestone](event, callMeOnEvent);
+
+      // Now save and load to make sure all lifecycle would be covered.
+      x.save(function (err) {
+        expect(err).to.be.null;
+
+        if(called) { return done(); }
+
+        // Now search for it.
+        TestMdl.findByName(searchStr, function (err, res) {
+          expect(err).to.be.null;
+          expect(res).to.be.an('array');
+          expect(res.length).to.equal(1);
+
+          if (called) { return done(); }
+
+          // Finally remove it.
+          res[0].remove(function (err) {
+            expect(err).to.be.null;
+            expect(called).to.be.true;
+
+            return done();
+          });
+        });
+      });
+    });
+  };
+
+  for (var x = 0; x < milestones.length; x++) {
+    var milestone = milestones[x];
+
+    for (var y = 0; y < events.length; y++) {
+      var event = events[y];
+
+      testMilestoneEvent(milestone, event);
+    };
+  }
+
+});


### PR DESCRIPTION
The hook system (pre/post) had a number of issues; this PR fixes all of them:

1. Hook functions are now called with consistent arguments; it's now been standardized and documented that a hook function is always called with (modelInst, callback)
2. If a hook function indicates an error (i.e. pre-save) then ottoman will not continue on to save the item.  This allows for custom validation with pre-save hooks.
3. Unit tests have been added that verify all hooks are called at the appropriate lifecycle stage for the model.
4. Documentation was inconsistent between model instance and schema, and has been fixed; model instance docs claimed to support validate|save|load events, but schema supported validate|save|remove.  Load was added to schema support, and both load and remove signals were fixed and are now called correctly.