### PR TITLE
Plugin system for Ottoman

### DIFF
--- a/lib/modelinstance.js
+++ b/lib/modelinstance.js
@@ -711,6 +711,23 @@ ModelInstance.refByKey = function(key) {
 };
 
 /**
+ * Registers a plugin for this model.  This function will be
+ * called immediately with the model itself as the first argument,
+ * and the provided options as the second argument.
+ * @param {pluginFn} the plugin function.
+ * @param {option} options object to pass to the plugin.
+ * @returns {ModelInstance}
+ */
+ModelInstance.plugin = function(pluginFn, options) {
+  if (!(pluginFn instanceof Function)) {
+    throw new Error('Ottoman plugins must be functions');
+  }
+
+  pluginFn(this, (options || {}));
+  return this;
+};
+
+/**
  * Creates an unloaded model instance referencing a data store item by id.
  *
  * @param {string} id

--- a/lib/ottoman.js
+++ b/lib/ottoman.js
@@ -35,6 +35,10 @@ function Ottoman(options) {
   this.types = {};
   this.delayedBind = {};
 
+  // Plugins are an array of arrays.
+  // Each item has two elements: a [pluginFn, options]
+  this.plugins = [];
+
   // Define the special `bucket` property which allows you to quickly
   //   specify a Couchbase Bucket to use without messing with the
   //   underlying StoreAdapters.
@@ -63,6 +67,23 @@ function Ottoman(options) {
     this.namespace = options.namespace;
   }
 }
+
+/**
+ * Registers a global plugin with ottoman.  Global plugins will be
+ * attached to all models defined *after* this call.
+ * @param pluginFn the plugin, which must be a function.
+ * @param options an options object to pass to the plugin function
+ * when it is called.
+ * @returns the ottoman singleton for chaining.
+ */
+Ottoman.prototype.plugin = function(pluginFn, options) {
+  if (!(pluginFn instanceof Function)) {
+    throw new Error('Ottoman plugins must be functions');
+  }
+
+  this.plugins.push([pluginFn, (options || {})]);
+  return this;
+};
 
 /**
  * Returns the currently specific namespace prefix for this manager.
@@ -145,18 +166,18 @@ Ottoman.prototype._parseFieldType = function(options) {
       this._parseFieldType(options[0])
     );
   }
-  
+
   // When a type is specified like this:
   // ottoman.model('Foo', { someField: ['string'] })
-  // Then per the docs that is legitimate.  But here we arrive with an 
+  // Then per the docs that is legitimate.  But here we arrive with an
   // options object of just 'string' which isn't valid.   So re-wrap it
   // in the format this function expects, and keep going.
   if(typeof options === 'string') {
-    return this._parseFieldType({ type: options });  
+    return this._parseFieldType({ type: options });
   }
-  
+
   if (!(options instanceof Object)) {
-    throw new Error('Unexpected field options type; expected either a ' + 
+    throw new Error('Unexpected field options type; expected either a ' +
                     'valid ottoman type or an object with a type property');
   }
 
@@ -281,7 +302,7 @@ Ottoman.prototype._createSchema = function(name, schemaDef, options) {
 
   for (var i in schemaDef) {
     /* istanbul ignore else */
-    if (schemaDef.hasOwnProperty(i)) {      
+    if (schemaDef.hasOwnProperty(i)) {
       var field = this._makeField(i, schemaDef[i]);
       schema.addField(field);
     }
@@ -352,7 +373,7 @@ function(model, fields, values, options, callback) {
       callback(err, null);
       return;
     }
-    
+
     var mdl = model.refByKey(data);
 
     var loadArgs = [function(err) {
@@ -369,7 +390,7 @@ function(model, fields, values, options, callback) {
     if (options.load) {
       loadArgs = options.load.concat(loadArgs);
     }
-    
+
     mdl.load.apply(mdl, loadArgs);
   });
 };
@@ -591,7 +612,7 @@ Ottoman.prototype._findModels = function(model, filter, options, callback) {
         callback(null, results);
       }
     }
-    
+
     var loadArgs = [handler];
     if (options.load) {
       loadArgs = options.load.concat(loadArgs);
@@ -663,6 +684,7 @@ Ottoman.prototype._buildModel = function(name, schemaDef, options) {
   model.namePath = ModelInstance.namePath;
   model.ref = ModelInstance.ref;
   model.refByKey = ModelInstance.refByKey;
+  model.plugin = ModelInstance.plugin;
   model.getById = ModelInstance.getById;
   model.fromData = ModelInstance.fromData;
   model.pre = ModelInstance.pre;
@@ -736,7 +758,21 @@ Ottoman.prototype._buildAndRegisterModel = function(name, schemaDef, options) {
     delete this.delayedBind[name];
   }
 
+  this._applyPlugins(model);
+
   return model;
+};
+
+/**
+ * Applies global plugins to models as they are created.
+ * @param {model} a new model that has been created.
+ * @returns the ottoman singleton for chaining.
+ */
+Ottoman.prototype._applyPlugins = function(model) {
+  for (var i = 0, l = this.plugins.length; i < l; i++) {
+    model.plugin(this.plugins[i][0], this.plugins[i][1]);
+  }
+  return this;
 };
 
 /**

--- a/test/model-references.test.js
+++ b/test/model-references.test.js
@@ -1,0 +1,197 @@
+var chai = require('chai');
+var expect = chai.expect;
+var H = require('./harness');
+var ottoman = H.lib;
+
+describe('Model references', function () {
+  this.timeout(2000000);
+
+  var idA = H.uniqueId('model');
+  var idB = H.uniqueId('model');
+  var idC = H.uniqueId('model');
+
+  var Account = ottoman.model(idA, {
+    email: 'string',
+    name: 'string'
+  });
+
+  var User = ottoman.model(idB, {
+    username: 'string',
+    account: { ref: Account },
+  }, {
+      index: {
+        findByUsername: {
+          type: 'n1ql',
+          by: 'username',
+          consistency: ottoman.Consistency.GLOBAL,
+        }
+      }
+    });
+
+  var MultiAccountUser = ottoman.model(idC, {
+    username: 'string',
+    accounts: [ {ref: Account }]
+  }, {
+    index: {
+      findByUsername: {
+        type: 'n1ql',
+        by: 'username',
+        consistency: ottoman.Consistency.GLOBAL,
+      }
+    }
+  })
+
+  before(function (done) {
+    ottoman.ensureIndices(function (err) {
+      if (err) { return done(err); }
+      setTimeout(function () { done(); }, 2000);
+    });
+  });
+
+  it('shouldn\'t require reference to be present', function (done) {
+    var notLinked = new User({
+      username: 'foo',
+    });
+
+    notLinked.save(function (err) {
+      if (err) { return done(err); }
+
+      expect(notLinked.username).to.be.ok;
+      done();
+    });
+  });
+
+  it('should permit referencing two models together', function (done) {
+    var myAccount = new Account({
+      email: 'burtteh@fakemail.com',
+      name: 'Brett Lawson'
+    });
+
+    var myUser = new User({
+      username: 'brett19',
+      account: myAccount,
+    });
+
+    myAccount.save(function (err) {
+      if (err) { return done(err); }
+
+      myUser.save(function (err) {
+        if (err) { return done(err); }
+
+        User.findByUsername('brett19', function (err, myUsers) {
+          // console.log('USERS: ' + JSON.stringify(myUsers));
+          expect(myUsers).to.be.an('array');
+          expect(myUsers.length).to.equal(1);
+
+          var myUser = myUsers[0];
+
+          // console.log(JSON.stringify(myUser));
+          // console.log('Loaded? ' + myUser.account.loaded());
+          expect(myUser.account.loaded()).to.be.false;
+
+          myUser.account.load(function (err) {
+            expect(myUser.account.email).to.equal('burtteh@fakemail.com');
+            done();
+          });
+        });
+      });
+    });
+  });
+
+  it('should allow re-linking of models', function (done) {
+    var notLinked = new User({
+      username: 'relink',
+    });
+
+    notLinked.save(function (err) {
+      if (err) { return done(err); }
+
+      expect(notLinked.username).to.be.ok;
+
+      var newLinkage = new Account({
+        email: 'foo@bar.com',
+        name: 'Foobar',
+      });
+
+      newLinkage.save(function (err) {
+        if (err) { return done(err); }
+
+        notLinked.account = newLinkage;
+
+        notLinked.save(function (err) {
+          if (err) { return done(err); }
+
+          User.findByUsername('relink', function (err, users) {
+            expect(users).to.be.an('array');
+            expect(users.length).to.equal(1);
+            var relinked = users[0];
+
+            expect(relinked.account.loaded()).to.be.false;
+            expect(relinked.account).to.be.ok;
+
+            relinked.account.load(function (err) {
+              if (err) { return done(err); }
+
+              expect(relinked.account.email).to.equal('foo@bar.com');
+              done();
+            });
+          });
+        });
+      });
+    });
+  });
+
+  it('should allow one-to-many linkages', function (done) {
+
+    var account1 = new Account({
+      email: 'account1@fake.com',
+      name: 'Account1'
+    });
+
+    var account2 = new Account({
+      email: 'account2@fake.com',
+      name: 'Account2'
+    });
+
+    var myUser = new MultiAccountUser({
+      username: 'multi-account',
+      accounts: [account1, account2]
+    });
+
+    var toSave = [account1, account2, myUser];
+    var saved = 0;
+
+    function proceed () {
+      MultiAccountUser.findByUsername('multi-account', function (err, users) {
+        if (err) { return done(err); }
+        expect(users).to.be.an('array');
+        expect(users.length).to.equal(1);
+
+        var multiUser = users[0];
+
+        expect(multiUser.accounts).to.be.an('array');
+        expect(multiUser.accounts.length).to.equal(2);
+
+        for(var i=0; i<multiUser.accounts.length; i++) {
+
+          expect(multiUser.accounts[i].loaded()).to.be.false;
+        }
+
+        done();
+      });
+    }
+
+    function saveCallback(err) {
+      if (err) { return done(err); }
+
+      saved++;
+      if(saved === toSave.length) {
+        proceed();
+      }
+    }
+
+    toSave.forEach(function (model) {
+      model.save(saveCallback);
+    });
+  });
+});

--- a/test/plugins.test.js
+++ b/test/plugins.test.js
@@ -1,0 +1,138 @@
+var chai = require('chai');
+var expect = chai.expect;
+var H = require('./harness');
+var ottoman = H.lib;
+
+function makeAMockModel() {
+  var mock = H.uniqueId('mock');
+  var Mock = ottoman.model(mock, {
+    email: 'string',
+    name: 'string'
+  });
+
+  return Mock;
+}
+
+function dummyPlugin() {
+  var p = function (model, options) {
+    options.called = true;
+    return this;
+  }
+
+  return p;
+}
+
+/**
+ * Tests for the Ottoman plugin system.
+ * Because the ottoman plugin system is derived in part from how Mongoose works,
+ * the sample use cases shown on their plugins page form a baseline for how to
+ * test this:
+ * http://mongoosejs.com/docs/plugins.html
+ */
+describe('Ottoman Plugins', function () {
+  beforeEach(function (done) {
+    ottoman.plugins = [];
+    done();
+  });
+
+  it('should register global, but not call it immediately', function (done) {
+    var plugin = dummyPlugin();
+    var watch = { called: false };
+    ottoman.plugin(plugin, watch);
+    expect(watch.called).to.be.false;
+    done();
+  });
+
+  // Note that these tests, by passing a "watch" variable that gets modified,
+  // also prove that the plugin is called with specified arguments, so that's
+  // not a separate unit test.
+  it('should register model plugin, and call it immediately', function (done) {
+    var plugin = dummyPlugin();
+    var model = makeAMockModel();
+    var watch = { called: false };
+    model.plugin(plugin, watch);
+    expect(watch.called).to.be.true;
+    done();
+  });
+
+  it('should provide the model when calling plugin', function (done) {
+    var model = null;
+
+    function pluginFn(modelArg, options) {
+      // Here, I want == and **not** === because I want reference equality */
+      /* eslint eqeqeq: "off" */
+      if (modelArg == model) {
+        options.good = true;
+      }
+    }
+
+    var watch = { good: false };
+    model = makeAMockModel();
+    model.plugin(pluginFn, watch);
+
+    expect(watch.good).to.be.true;
+    done();
+  });
+
+  it('should let models inherit global plugins', function (done) {
+    var plugin = dummyPlugin();
+    var watch = { called: false };
+
+    // Register a global plugin.
+    ottoman.plugin(plugin, watch);
+
+    // Didn't get called globally.
+    expect(watch.called).to.be.false;
+
+    // Define some model, don't care which.
+    // On that definition, plugin should auto-run on it.
+    makeAMockModel();
+
+    // On model registration, plugin got called.
+    expect(watch.called).to.be.true;
+
+    done();
+  });
+
+  it('should allow an arbitrary number of plugins', function (done) {
+    function pluginFn(model, options) {
+      options.counter = options.counter + 1;
+    }
+
+    var watch = { counter: 0 };
+
+    for (var i = 0; i < 100; i++) {
+      ottoman.plugin(pluginFn, watch);
+    }
+
+    makeAMockModel();
+
+    expect(watch.counter).to.equal(100);
+    done();
+  });
+
+  it('should work properly with an ottoman event', function (done) {
+    function fooSetterPlugin(model, options) {
+      model.pre('save', function (modelInstance, next) {
+        modelInstance.foo = options.foo;
+        next();
+      });
+    }
+
+    var mock = H.uniqueId('mock');
+    var Mock = ottoman.model(mock, {
+      x: 'string',
+      foo: { type: 'string', default: null }
+    });
+
+    Mock.plugin(fooSetterPlugin, { foo: 'bar' });
+
+    var myMock = new Mock({ x: 'hello' });
+    myMock.save(function (err) {
+      if (err) { return done(err); }
+
+      expect(myMock.foo).to.equal('bar');
+      done();
+    });
+  });
+});


### PR DESCRIPTION
This commit introduces a plugin system for Ottoman.  Plugins are tiny functions that take model instances and options as arguments.  They use the eventing system (pre/post save, load, etc) to perform useful functions.

A plugin system is an important piece to have because it lets users extend ottoman functionality with stuff that doesn't really belong in Ottoman proper.

This commit comes with unit tests covering 100% of the new code introduced.

Finally -- the setup of this plugin system is based on Mongoose, which has a decent ecosystem for plugins, and a very simple implementation.  Below are some links showing correspondence between what I did in this commit and what's in mongoose's source code.  The code is pretty self-explanatory, but the parallels between the two are clear (and intentional).

[Mongoose - how to register global plugins](https://github.com/Automattic/mongoose/blob/master/lib/index.js#L450)

[Mongoose plugins on model instances](https://github.com/Automattic/mongoose/blob/master/lib/schema.js#L962)

[Mongoose application of global plugins to created models](https://github.com/Automattic/mongoose/blob/master/lib/index.js#L431)


