### PR TITLE
add Ottoman__type to the list of indexes to be built after deferral

### DIFF
--- a/lib/cbstoreadapter.js
+++ b/lib/cbstoreadapter.js
@@ -471,9 +471,15 @@ CbStoreAdapter.prototype._ensureGsiIndices = function (callback) {
 
   var createOttomanTypeIndex = function (err) {
     if (err) { return callback(err); }
-    var q = 'CREATE INDEX `Ottoman__type` on `' +
+    var typeIndex = 'Ottoman__type';
+
+    var q = 'CREATE INDEX `' + typeIndex + '` on `' +
       b._name + '`(`_type`) ' +
       'USING GSI WITH {\"defer_build\": true}';
+
+    // Add this to the list of deferred indexes that get built later.
+    indexes.push(typeIndex);
+
     return b.query(couchbase.N1qlQuery.fromString(q),
       runSubsequentIndexQueries);
   };


### PR DESCRIPTION
This is a small change, my omission when I put in an earlier PR.

All index builds are deferred, so the previous PR scheduled a build for an index, but didn't actually build it.

All this PR does is add the index to the list of things that are built, so that after ottoman runs all of the relevant `CREATE INDEX` statements, and later runs `BUILD INDEX`, the Ottoman__type index is included in the list of what's built.