### PR TITLE
Ottoman issue #98; patching index creation for couchbase 4.5.0

### DIFF
--- a/lib/cbstoreadapter.js
+++ b/lib/cbstoreadapter.js
@@ -3,6 +3,7 @@
 var util = require('util');
 var ottopath = require('./ottopath');
 var StoreAdapter = require('./storeadapter');
+var Promise = require('bluebird');
 
 var couchbase = null;
 try {
@@ -392,116 +393,61 @@ CbStoreAdapter.prototype._ensureGsiIndices = function (callback) {
   }
 
   // Set reference so inner callbacks can use this.
-  var storeAdapter = this;
+  var self = this;
 
-  var proced = 0;
+  // Simple way of turning n1ql query into a chainable promise.
+  // TODO when couchbase is later more promisified, this shouldn't be here,
+  // but would be preferable as a bucket.query() convenience method.
+  var queryPromise = function (stringQuery) {
+    return new Promise(function (resolve, reject) {
+      var n1ql = couchbase.N1qlQuery.fromString(stringQuery);
 
-  // In couchbase 4.0.0, trying to build an index that already existed
-  // would work (and silently do basically nothing).  In couchbase 4.5.0,
-  // building an index that's already there is an error.
-  // Because ottoman builds all indexes each time, it needs to know which
-  // errors can safely be ignored.  These errors indicate that the intent
-  // (creating indexes) has been safely executed without creating problems up
-  // the call chain.
-  function isIgnoreableIndexError (err) {
-    if (!err) { return true; }
+      return self.bucket.query(n1ql, function (err, rows, meta) {
+        var str = (err ? err.toString() : '');
+        // Ignore "already exists" and "already built" errors that
+        // may arise in cb 4.5 if we have previously tried to create them.
+        if (err &&
+          !str.match(/index.*already exists/i) &&
+          !str.match(/index.*is being built/i) &&
+          !str.match(/index.*already built/i)) {
+          return reject(err);
+        }
 
-    var str = err.toString();
-    return str.match(/index.*already exists/i) > -1 ||
-           str.match(/index.*already built/i) > -1;
-  }
-
-  // Takes a query as an argument, returns a handler.
-  // Previous version would indicate failure, without indicating
-  // which n1ql query failed.
-  function indexCreateCompleteHandler(query) {
-    return function (err) {
-      if (err && !isIgnoreableIndexError(err)) {
-        console.error('Failed to create index indicated via ' +
-          query + ' -- ' + err);
-        proced = queries.length;
-        callback(err);
-        return;
-      }
-
-      proced++;
-      if (proced === queries.length) {
-        // At this point, all index creation worked.
-        // Final step (which can only be done once all indexes
-        // have been created) is to issue BUILD INDEX on all of
-        // them.
-        // If you do this with the rest of the batch, this query
-        // will run before all indexes are created, and it will
-        // die with an error that a referenced index doesn't
-        // exist.
-        var buildQuery =
-          'BUILD INDEX ON `' + storeAdapter.bucket._name + '`(' +
-          indexes.map(function (idx) {
-            return '`' + idx + '`';
-          }).join(',') +
-          ') USING GSI';
-
-        var n1ql = couchbase.N1qlQuery.fromString(buildQuery);
-        storeAdapter.bucket.query(n1ql,
-          function (err) {
-            if (err && !isIgnoreableIndexError(err)) {
-              return callback(err);
-            }
-
-            return callback(null);
-          });
-
-        return;
-      }
-    };
-  }
-
-  /*
-    * After create primary index, this loops through and runs all
-    * of the CREATE INDEX statements.
-    */
-  var runSubsequentIndexQueries = function (err) {
-    if (err && !isIgnoreableIndexError(err)) {
-      return callback(err);
-    }
-
-    // If it did, run all of the dependent index creation.
-    if (!queries || !queries.length) {
-      return callback(null);
-    }
-    for (var l = 0; l < queries.length; ++l) {
-      var query = queries[l];
-
-      storeAdapter.bucket.query(couchbase.N1qlQuery.fromString(query),
-        indexCreateCompleteHandler(query));
-    }
+        return resolve({ rows: rows, meta: meta });
+      });
+    });
   };
 
-  var b = this.bucket;
+  // This promise chain creates all indexes in proper order.
+  // Create primary index; without this, nothing works.
+  queryPromise('CREATE PRIMARY INDEX ON `' + this.bucket._name + '` USING GSI')
+    .then(function () {
+      // Create ottoman type index, needed to make model lookups fast.
+      return queryPromise('CREATE INDEX `Ottoman__type` ON ' +
+        self.bucket._name + '(`_type`) USING GSI WITH {"defer_build": true}');
+    })
+    .then(function () {
+      // Map createIndex across all individual n1ql model indexes.
+      // concurrency: 1 is important to avoid overwhelming server.
+      // Promise.all turns the array into a single promise again.
+      return Promise.all(Promise.map(queries, function (query) {
+        return queryPromise(query);
+      }, { concurrency: 1 }));
+    })
+    .then(function () {
+      // All indexes were built deferred, so now kick off actual build.
+      var buildEm = 'BUILD INDEX ON `' + self.bucket._name + '`(' +
+        indexes.map(function (idx) {
+          return '`' + idx + '`';
+        }).join(',') +
+        ') USING GSI';
+      return queryPromise(buildEm);
+    })
+    // If you've gotten this far, everything's good.
+    .then(function () { return callback(null); })
+    .catch(function (err) { return callback(err); });
 
-  var createOttomanTypeIndex = function (err) {
-    if (err && !isIgnoreableIndexError(err)) {
-      return callback(err);
-    }
-
-    var typeIndex = 'Ottoman__type';
-
-    var q = 'CREATE INDEX `' + typeIndex + '` on `' +
-      b._name + '`(`_type`) ' +
-      'USING GSI WITH {\"defer_build\": true}';
-
-    // Add this to the list of deferred indexes that get built later.
-    indexes.push(typeIndex);
-
-    return b.query(couchbase.N1qlQuery.fromString(q),
-      runSubsequentIndexQueries);
-  };
-
-  // Kick the whole thing off by creating primary index
-  var primaryIndexFirst = 'CREATE PRIMARY INDEX ON `' +
-    this.bucket._name + '` USING GSI';
-  return this.bucket.query(couchbase.N1qlQuery.fromString(primaryIndexFirst),
-    createOttomanTypeIndex);
+  return null;
 };
 
 /**

--- a/lib/cbstoreadapter.js
+++ b/lib/cbstoreadapter.js
@@ -396,12 +396,27 @@ CbStoreAdapter.prototype._ensureGsiIndices = function (callback) {
 
   var proced = 0;
 
+  // In couchbase 4.0.0, trying to build an index that already existed
+  // would work (and silently do basically nothing).  In couchbase 4.5.0,
+  // building an index that's already there is an error.
+  // Because ottoman builds all indexes each time, it needs to know which
+  // errors can safely be ignored.  These errors indicate that the intent
+  // (creating indexes) has been safely executed without creating problems up
+  // the call chain.
+  function isIgnoreableIndexError (err) {
+    if (!err) { return true; }
+
+    var str = err.toString();
+    return str.match(/index.*already exists/i) > -1 ||
+           str.match(/index.*already built/i) > -1;
+  }
+
   // Takes a query as an argument, returns a handler.
   // Previous version would indicate failure, without indicating
   // which n1ql query failed.
   function indexCreateCompleteHandler(query) {
     return function (err) {
-      if (err) {
+      if (err && !isIgnoreableIndexError(err)) {
         console.error('Failed to create index indicated via ' +
           query + ' -- ' + err);
         proced = queries.length;
@@ -426,17 +441,10 @@ CbStoreAdapter.prototype._ensureGsiIndices = function (callback) {
           }).join(',') +
           ') USING GSI';
 
-        // console.log("Running final build.... " +
-        //             buildIndexQuery);
         var n1ql = couchbase.N1qlQuery.fromString(buildQuery);
         storeAdapter.bucket.query(n1ql,
           function (err) {
-            // console.log('BUILD INDEXES: ' + buildIndexQuery +
-            //     ' err=' + err +
-            //     ' rows=' + JSON.stringify(rows) +
-            //     ' meta=' + JSON.stringify(meta));
-
-            if (err) {
+            if (err && !isIgnoreableIndexError(err)) {
               return callback(err);
             }
 
@@ -453,7 +461,9 @@ CbStoreAdapter.prototype._ensureGsiIndices = function (callback) {
     * of the CREATE INDEX statements.
     */
   var runSubsequentIndexQueries = function (err) {
-    if (err) { return callback(err); }
+    if (err && !isIgnoreableIndexError(err)) {
+      return callback(err);
+    }
 
     // If it did, run all of the dependent index creation.
     if (!queries || !queries.length) {
@@ -470,7 +480,10 @@ CbStoreAdapter.prototype._ensureGsiIndices = function (callback) {
   var b = this.bucket;
 
   var createOttomanTypeIndex = function (err) {
-    if (err) { return callback(err); }
+    if (err && !isIgnoreableIndexError(err)) {
+      return callback(err);
+    }
+
     var typeIndex = 'Ottoman__type';
 
     var q = 'CREATE INDEX `' + typeIndex + '` on `' +

--- a/package.json
+++ b/package.json
@@ -14,6 +14,7 @@
     "test": "eslint ./lib && istanbul cover ./node_modules/mocha/bin/_mocha -- test/*.test.js"
   },
   "dependencies": {
+    "bluebird": "^3.4.1",
     "jsonpath": "~0.2.2",
     "uuid": "~2.0.1"
   },


### PR DESCRIPTION
This appears to be the only major thing I can find that blocks ottoman from being used with couchbase 4.5.0.  Still better test coverage is necessary to be sure, but for me with this change, ottoman runs through all of its tests against a local docker image of couchbase 4.5.0.  Without this change, ottoman fails to run its tests.  The index creation process fails with error messages about indexes already existing, as specified on the github issue.