### PR TITLE
fixed missing index in cases where no other n1ql indexes were present

### DIFF
--- a/lib/cbstoreadapter.js
+++ b/lib/cbstoreadapter.js
@@ -422,6 +422,7 @@ CbStoreAdapter.prototype._ensureGsiIndices = function (callback) {
   // Create primary index; without this, nothing works.
   queryPromise('CREATE PRIMARY INDEX ON `' + this.bucket._name + '` USING GSI')
     .then(function () {
+      indexes.push('Ottoman__type');
       // Create ottoman type index, needed to make model lookups fast.
       return queryPromise('CREATE INDEX `Ottoman__type` ON ' +
         self.bucket._name + '(`_type`) USING GSI WITH {"defer_build": true}');


### PR DESCRIPTION
Fixes an edge case; when `ensureOttomanIndexes` runs but the user has not specified any indexes, creation process fails because the `indexes` array is empty.  Additionally, the `Ottoman__type` index may not be built.  