### PR TITLE
support for type { ref: "Mixed" } with associated tests

### DIFF
--- a/lib/modelinstance.js
+++ b/lib/modelinstance.js
@@ -212,7 +212,9 @@ function _encodeValue(context, type, value, forceTyping, f) {
     if (!(value instanceof ModelInstance)) {
       throw new Error('Expected ' + f.name + ' type to be a ModelInstance.');
     }
-    if (type.name !== value.$.schema.name) {
+    // Values must match stated type names, unless the reference is to
+    // 'Mixed', then any reference will do.
+    if (type.name !== value.$.schema.name && (type.name !== 'Mixed')) {
       throw new Error('Expected type to be `' +
         type.name + '` (got `' + value.$.schema.name + '`)');
     }

--- a/lib/ottoman.js
+++ b/lib/ottoman.js
@@ -204,7 +204,11 @@ Ottoman.prototype._parseFieldType = function (options) {
       options.ref = options.ref.name;
     } else {
       var typeObj = this.typeByName(options.ref);
-      if (Schema.isCoreType(typeObj)) {
+
+      // As a special exception, you **are** allowed to create { ref: 'Mixed' }
+      // to make a reference to any other type.  So Mixed is the only
+      // "core type" you can create a reference to, others don't make sense.
+      if (Schema.isCoreType(typeObj) && !(typeObj === Schema.MixedType)) {
         throw new Error('References cannot point to core types.');
       }
     }

--- a/lib/schema.js
+++ b/lib/schema.js
@@ -429,6 +429,18 @@ function _decodeValue(context, type, data) {
     if (!modelType) {
       throw new Error('Invalid type specified (' + type.name + ')');
     }
+
+    if ((modelType.type && modelType.type === 'Mixed') ||
+      modelType === Schema.Mixed) {
+      // This is a mixed type reference, so we have to get the type from
+      // the **reference**, not from the defined model type (Mixed)
+      modelType = context.typeByName(data._type);
+
+      if (!modelType) {
+        throw new Error('Invalid type in mixed reference (' + data._type + ')');
+      }
+    }
+
     return modelType.ref(data.$ref);
   } else if (data instanceof Object && data._type) {
     if (type === mixedCoreType) {
@@ -543,7 +555,10 @@ function _decodeUserValue(context, type, data) {
     return outObj;
   } else if (type instanceof ModelRef) {
     var expectedType = context.typeByName(type.name);
-    if (!(data instanceof expectedType)) {
+
+    if (type.name === 'Mixed' || expectedType === Schema.Mixed) {
+      // Pass; mixed references are permitted.
+    } else if (!(data instanceof expectedType)) {
       throw new Error('Expected value to be a ModelInstance of type `' +
         type.name + '`.');
     }


### PR DESCRIPTION
Via skype discussion, this creates the ability to have models with mixed references, like this:

```
ottoman.model('MixedRefs', { 
   aRef: { ref: 'Mixed' },
});
```

Unit tests are added, and adjustments are made to ensure that errors are thrown at serialization time to avoid having any data (integers, strings) put into a mixed reference type.