### PR TITLE
alternative to _type (leading underscore problem with sync gateway)

### DIFF
--- a/lib/cbstoreadapter.js
+++ b/lib/cbstoreadapter.js
@@ -16,9 +16,10 @@ try {
  * The Couchbase store adapter implements an Ottoman StoreAdapter suitable
  *   for using Ottoman with Couchbase Server.
  * @param bucket
+ * @param ottomanType
  * @constructor
  */
-function CbStoreAdapter(bucket, cb) {
+function CbStoreAdapter(bucket, ottomanType, cb) {
   StoreAdapter.call(this);
 
   if (!cb) {
@@ -43,6 +44,7 @@ function CbStoreAdapter(bucket, cb) {
   this.ddocs = {};
   this.gsis = {};
   this.debug = false;
+  this.ottomanType = ottomanType;
 }
 util.inherits(CbStoreAdapter, StoreAdapter);
 
@@ -141,10 +143,10 @@ CbStoreAdapter.prototype.remove = function (key, cas, callback) {
  * @private
  * @ignore
  */
-function _buildViewMapFn(schemaName, fields) {
+function _buildViewMapFn(schemaName, fields, ottomanType) {
   var out = '';
   out += 'function(doc, meta) {\n';
-  out += '  if(doc._type === \'' + schemaName + '\') {\n';
+  out += '  if(doc.' + ottomanType + ' === \'' + schemaName + '\') {\n';
 
   var fieldArr = [];
   for (var i = 0; i < fields.length; ++i) {
@@ -174,7 +176,7 @@ function _buildViewMapFn(schemaName, fields) {
  */
 CbStoreAdapter.prototype._createViewIndex =
   function (modelName, name, fields, callback) {
-    var mapFnStr = _buildViewMapFn(modelName, fields);
+    var mapFnStr = _buildViewMapFn(modelName, fields, this.ottomanType);
 
     if (this.debug) {
       console.log('Map Function:', mapFnStr);
@@ -277,7 +279,7 @@ CbStoreAdapter.prototype._ensureMrIndices = function (callback) {
     data: {
       views: {
         count_items: {
-          map: 'function(doc,meta){emit(doc._type,null);}',
+          map: 'function(doc,meta){emit(doc' + this.ottomanType + ',null);}',
           reduce: '_count'
         }
       }
@@ -343,6 +345,7 @@ function _ottopathToN1qlPath(path) {
 CbStoreAdapter.prototype._ensureGsiIndices = function (callback) {
   var queries = [];
   var indexes = [];
+  var ottomanType = this.ottomanType;
 
   // Build a list of indexes to create.
   // General strategy for this function is to first issue a
@@ -404,7 +407,7 @@ CbStoreAdapter.prototype._ensureGsiIndices = function (callback) {
         'ON `' + this.bucket._name + '`(' +
         fieldNames.join(',') +
         ') ' +
-        'WHERE _type="' + gsi.modelName + '" ' +
+        'WHERE ' + ottomanType + '="' + gsi.modelName + '" ' +
         'USING GSI WITH {\"defer_build\": true}');
 
       // Keep track of all indexes we are creating, so we can
@@ -446,7 +449,8 @@ CbStoreAdapter.prototype._ensureGsiIndices = function (callback) {
       indexes.push('Ottoman__type');
       // Create ottoman type index, needed to make model lookups fast.
       return queryPromise('CREATE INDEX `Ottoman__type` ON ' +
-        self.bucket._name + '(`_type`) USING GSI WITH {"defer_build": true}');
+        self.bucket._name + '(`' + ottomanType
+          + '`) USING GSI WITH {"defer_build": true}');
     })
     .then(function () {
       // Map createIndex across all individual n1ql model indexes.
@@ -717,7 +721,7 @@ CbStoreAdapter.prototype.count = function (type, modelName, options, callback) {
   }
 
   var expressions = [];
-  expressions.push('_type=\'' + modelName + '\'');
+  expressions.push(this.ottomanType +'=\'' + modelName + '\'');
   if (options.filter) {
     _buildFilterExprs(options.filter, expressions);
   }
@@ -771,7 +775,7 @@ CbStoreAdapter.prototype.find = function (type, modelName, options, callback) {
   }
 
   var expressions = [];
-  expressions.push('_type=\'' + modelName + '\'');
+  expressions.push(this.ottomanType + '=\'' + modelName + '\'');
   if (options.filter) {
     _buildFilterExprs(options.filter, expressions);
   }

--- a/lib/mockstoreadapter.js
+++ b/lib/mockstoreadapter.js
@@ -11,12 +11,13 @@ function makeCas() {
   return Math.floor(Math.random() * 10000000);
 }
 
-function MockStoreAdapter() {
+function MockStoreAdapter(ottomanType) {
   StoreAdapter.call(this);
 
   this.data = {};
   this.indexes = {};
   this.debug = false;
+  this.ottomanType = ottomanType;
 }
 util.inherits(MockStoreAdapter, StoreAdapter);
 
@@ -234,13 +235,14 @@ MockStoreAdapter.prototype.find =
     if (this.debug) {
       console.log('MockStoreAdapter::find', type, modelName, options);
     }
+    var ottomanType = this.ottomanType;
 
     process.nextTick(function () {
       var results = [];
       for (var i in this.data) {
         if (this.data.hasOwnProperty(i)) {
           var keyValue = this.data[i].value;
-          if (keyValue._type !== modelName) {
+          if (keyValue[ottomanType] !== modelName) {
             continue;
           }
           if (!_testDocFilter(options.filter, keyValue)) {

--- a/lib/modelinstance.js
+++ b/lib/modelinstance.js
@@ -35,6 +35,7 @@ function ModelInstance() {
   $.cas = null;
   $.loaded = false;
   $.refKeys = [];
+  $.ottomanType = this.constructor.schema.context.ottomanType;
 
   if (args.length === 1 && args[0] instanceof ModelData) {
     $.key = args[0].key;
@@ -174,7 +175,7 @@ function _findField(fields, name) {
   return null;
 }
 
-function _encodeValue(context, type, value, forceTyping, f) {
+function _encodeValue(context, type, value, forceTyping, f, ottomanType) {
   if (context.isModel(type)) {
     if (!(value instanceof type)) {
       throw new Error('Expected ' + f.name + ' type to be a `' +
@@ -187,7 +188,8 @@ function _encodeValue(context, type, value, forceTyping, f) {
     }
     var outArr = [];
     for (var i = 0; i < value.length; ++i) {
-      outArr[i] = _encodeValue(context, type.type, value[i], forceTyping, f);
+      outArr[i] = _encodeValue(context, type.type, value[i],
+        forceTyping, f, ottomanType);
     }
     return outArr;
   } else if (type instanceof Schema.FieldGroup) {
@@ -204,7 +206,7 @@ function _encodeValue(context, type, value, forceTyping, f) {
           throw new Error('Cannot find field data for property `' + j + '`.');
         }
         outObj[j] = _encodeValue(context, field.type, value[j],
-          forceTyping, field);
+          forceTyping, field, ottomanType);
       }
     }
     return outObj;
@@ -218,10 +220,11 @@ function _encodeValue(context, type, value, forceTyping, f) {
       throw new Error('Expected type to be `' +
         type.name + '` (got `' + value.$.schema.name + '`)');
     }
-    return {
-      '_type': value.$.schema.namePath(),
+    var obj = {
       '$ref': value.id()
     };
+    obj[ottomanType] = value.$.schema.namePath();
+    return obj;
   } else if (type === Schema.DateType) {
     if (!(value instanceof Date)) {
       // throw new Error('Expected ' + f.name + ' type to be a Date.');
@@ -237,10 +240,11 @@ function _encodeValue(context, type, value, forceTyping, f) {
     if (value instanceof ModelInstance) {
       return value._toCoo(type.name, forceTyping);
     } else if (value instanceof Date) {
-      return {
-        '_type': 'Date',
+      var dateObj = {
         'v': value.toISOString()
       };
+      dateObj[ottomanType] = 'Date';
+      return dateObj;
     } else {
       return value;
     }
@@ -266,9 +270,9 @@ function _encodeValue(context, type, value, forceTyping, f) {
 ModelInstance.prototype._toCoo = function (refType, forceTyping) {
   var $ = this.$;
   var objOut = {};
-
+  var ottomanType = $.ottomanType;
   if (forceTyping || this.$.schema.name !== refType) {
-    objOut._type = this.$.schema.namePath();
+    objOut[ottomanType] = this.$.schema.namePath();
   }
 
   for (var i in this) {
@@ -277,7 +281,7 @@ ModelInstance.prototype._toCoo = function (refType, forceTyping) {
       var field = $.schema.field(i);
       objOut[i] =
         _encodeValue($.schema.context, field.type, this[i],
-          forceTyping, field);
+          forceTyping, field, ottomanType);
     }
   }
   return objOut;

--- a/lib/ottoman.js
+++ b/lib/ottoman.js
@@ -34,6 +34,7 @@ function Ottoman(options) {
   this.models = {};
   this.types = {};
   this.delayedBind = {};
+  this.ottomanType = process.env.OTTOMAN_TYPE || '_type';
 
   // Plugins are an array of arrays.
   // Each item has two elements: a [pluginFn, options]
@@ -52,7 +53,7 @@ function Ottoman(options) {
       }
     },
     set: function (bucket) {
-      this.store = new StoreAdapter.Couchbase(bucket);
+      this.store = new StoreAdapter.Couchbase(bucket, this.ottomanType);
     }
   });
 
@@ -683,6 +684,7 @@ Ottoman.prototype._buildModel = function (name, schemaDef, options) {
   util.inherits(model, ModelInstance);
 
   model.schema = schema;
+  model.ottomanType = this.ottomanType;
 
   model.create = ModelInstance.create;
   model.namePath = ModelInstance.namePath;
@@ -1007,13 +1009,13 @@ Ottoman.prototype.fromCoo = function (data, type) {
     type = this.nsPrefix() + type;
   }
 
-  if (data._type) {
+  if (data[this.ottomanType]) {
     if (type) {
-      if (type !== data._type) {
+      if (type !== data[this.ottomanType]) {
         throw new Error('Coo data was not of expected type.');
       }
     }
-    type = data._type;
+    type = data[this.ottomanType];
   } else {
     if (!type) {
       throw new Error('No type information could be deduced.');

--- a/lib/ottoman.js
+++ b/lib/ottoman.js
@@ -34,7 +34,11 @@ function Ottoman(options) {
   this.models = {};
   this.types = {};
   this.delayedBind = {};
-  this.ottomanType = process.env.OTTOMAN_TYPE || '_type';
+  this.ottomanType = '_type';
+
+  if (options.ottomanType) {
+    this.ottomanType = options.ottomanType;
+  }
 
   // Plugins are an array of arrays.
   // Each item has two elements: a [pluginFn, options]

--- a/lib/schema.js
+++ b/lib/schema.js
@@ -120,6 +120,7 @@ function Schema(context) {
   this.queryFns = [];
   this.preHandlers = {};
   this.postHandlers = {};
+  this.ottomanType = context.ottomanType;
 }
 
 Schema.prototype.namePath = function () {
@@ -417,7 +418,7 @@ function _fieldTypeSearchWildcard(obj) {
   }
 }
 
-function _decodeValue(context, type, data) {
+function _decodeValue(context, type, data, ottomanType) {
   if (data instanceof Object && data.$ref) {
     if (!(type instanceof ModelRef)) {
       throw new Error(
@@ -434,17 +435,18 @@ function _decodeValue(context, type, data) {
       modelType === Schema.Mixed) {
       // This is a mixed type reference, so we have to get the type from
       // the **reference**, not from the defined model type (Mixed)
-      modelType = context.typeByName(data._type);
+      modelType = context.typeByName(data[ottomanType]);
 
       if (!modelType) {
-        throw new Error('Invalid type in mixed reference (' + data._type + ')');
+        throw new Error('Invalid type in mixed reference ('
+          + data[ottomanType] + ')');
       }
     }
 
     return modelType.ref(data.$ref);
-  } else if (data instanceof Object && data._type) {
+  } else if (data instanceof Object && data[ottomanType]) {
     if (type === mixedCoreType) {
-      type = context.typeByName(data._type);
+      type = context.typeByName(data[ottomanType]);
       if (!type) {
         throw new Error('Could not deduce mixed type from data.');
       }
@@ -468,7 +470,7 @@ function _decodeValue(context, type, data) {
 
       var outArr = [];
       for (var i = 0; i < data.length; ++i) {
-        outArr[i] = _decodeValue(context, type.type, data[i]);
+        outArr[i] = _decodeValue(context, type.type, data[i], ottomanType);
       }
       return outArr;
     } else if (type instanceof FieldGroup) {
@@ -479,7 +481,7 @@ function _decodeValue(context, type, data) {
 
       var outObj = {};
       /*eslint-disable no-use-before-define */
-      _decodeFields(context, type.fields, outObj, data);
+      _decodeFields(context, type.fields, outObj, data, ottomanType);
       /*eslint-enable no-use-before-define */
       return outObj;
     } else if (type instanceof ModelRef) {
@@ -491,10 +493,10 @@ function _decodeValue(context, type, data) {
   }
 }
 
-function _decodeFields(context, fields, obj, data) {
+function _decodeFields(context, fields, obj, data, ottomanType) {
   for (var i in data) {
     if (data.hasOwnProperty(i)) {
-      if (i === '_type') {
+      if (i === ottomanType) {
         continue;
       }
 
@@ -503,7 +505,7 @@ function _decodeFields(context, fields, obj, data) {
         throw new Error('Could not find schema field for `' + i + '`.');
       }
 
-      obj[i] = _decodeValue(context, field.type, data[i]);
+      obj[i] = _decodeValue(context, field.type, data[i], ottomanType);
     }
   }
 }
@@ -601,7 +603,7 @@ Schema.prototype.fieldType = function (path) {
 };
 
 Schema.prototype.applyDataToObject = function (obj, data) {
-  _decodeFields(this.context, this.fields, obj, data);
+  _decodeFields(this.context, this.fields, obj, data, this.ottomanType);
 };
 
 Schema.prototype.applyUserDataToObject = function (obj, data) {

--- a/test/api.test.js
+++ b/test/api.test.js
@@ -27,7 +27,7 @@ describe('Public API', function () {
 
   var mdlInstance = new TestMdl({ name: 'foo' });
 
-  var adapterInst = new CbStoreAdapter({ 'bogusBucket': true }, {});
+  var adapterInst = new CbStoreAdapter({ 'bogusBucket': true }, ottoman.ottomanType, {});
 
   var publicAPI = {
     CbStoreAdapter: {

--- a/test/basic.test.js
+++ b/test/basic.test.js
@@ -3,6 +3,7 @@
 var assert = require('chai').assert;
 var H = require('./harness');
 var ottoman = H.lib;
+var ottomanType = ottoman.ottomanType;
 
 describe('Models', function () {
   // Add long timeout in case of slow response on CI build servers.
@@ -95,8 +96,8 @@ describe('Models', function () {
     var x = new TestMdl();
     var xJson = x.toCoo();
 
-    assert.typeOf(xJson._type, 'string');
-    assert.equal(xJson._type, ottoman.nsPrefix() + modelId);
+    assert.typeOf(xJson[ottomanType], 'string');
+    assert.equal(xJson[ottomanType], ottoman.nsPrefix() + modelId);
     assert.typeOf(xJson._id, 'string');
     assert.equal(xJson._id, x._id);
     assert.isUndefined(xJson.name);
@@ -187,9 +188,9 @@ describe('Models', function () {
   it('should fail to deserialize an unregistered type', function () {
     var modelId = H.uniqueId('model');
     var data = {
-      _type: modelId,
       name: 'Frank'
     };
+    data[ottomanType] = modelId;
     assert.throw(function () {
       ottoman.fromCoo(data);
     }, Error);
@@ -333,7 +334,7 @@ describe('Models', function () {
       var xJson = x.toCoo();
 
       assert.instanceOf(xJson.when, Object);
-      assert.equal(xJson.when._type, 'Date');
+      assert.equal(xJson.when[ottomanType], 'Date');
       assert.equal(xJson.when.v, x.when.toISOString());
     });
   });

--- a/test/harness.js
+++ b/test/harness.js
@@ -44,7 +44,7 @@ if (process.env.CNCSTR) {
 
   ottoman.bucket = bucket;
 } else {
-  ottoman.store = new ottoman.MockStoreAdapter();
+  ottoman.store = new ottoman.MockStoreAdapter(ottoman.ottomanType);
 }
 
 // Setup Ottoman

--- a/test/model-references.test.js
+++ b/test/model-references.test.js
@@ -67,7 +67,7 @@ describe('Model references', function () {
       var frozen = mixer.toCoo();
 
       expect(frozen.anyRef).to.be.an('object');
-      expect(frozen.anyRef._type).to.contain('throwaway');
+      expect(frozen.anyRef[ottoman.ottomanType]).to.contain('throwaway');
 
       // Demonstrate that when we bring it back from coo, the reference is
       // intact, and doesn't throw an error related to unknown types.


### PR DESCRIPTION
_type can be changed by setting env variable OTTOMAN_TYPE

I had the same issue as here: https://github.com/couchbaselabs/node-ottoman/issues/79
Therefore I made the "_type" configurable via environament variable.
If env variable is not set it uses the standard _type
