### PR TITLE
added validation recursing 

### DIFF
--- a/lib/schema.js
+++ b/lib/schema.js
@@ -126,14 +126,24 @@ Schema.prototype.namePath = function () {
   return this.context.nsPrefix() + this.name;
 };
 
-//This function is private so the API can run the pre/post handlers
+// This function is private so the API can run the pre/post handlers
 Schema.prototype._validate = function (mdlInst) {
+  // Anything which is a fieldGroup causes a DFS of the trees to validate
+  // any validators which are child elements in the tree
+  var validateTree = function(field, instSubTree) {
+    var current = instSubTree[field.name];
+    if (field.validator) {
+      field.validator(current);
+    } else if (field.type instanceof FieldGroup) { 
+      for (var j = 0; j < field.type.fields.length; ++j) {
+        var child = field.type.fields[j];
+        validateTree(child, current);
+      }
+    }
+  };
   for (var i = 0; i < this.fields.length; ++i) {
     var field = this.fields[i];
-
-    if (field.validator) {
-      field.validator(mdlInst[field.name]);
-    }
+    validateTree(field, mdlInst);
   }
 };
 

--- a/test/basic.test.js
+++ b/test/basic.test.js
@@ -717,12 +717,16 @@ describe('Models', function () {
 
   it('should validate a model', function () {
     var modelId = H.uniqueId('model');
+    var called = false;
     var TestMdl = ottoman.model(modelId, {
       name: {
         type: 'string',
         validator: function (value) {
           if (typeof (value) !== 'string') {
             throw new Error('bad data');
+          }
+          else { 
+            called = true;
           }
         }
       }
@@ -731,6 +735,7 @@ describe('Models', function () {
     var x = new TestMdl({ name: 'Joseph' });
     ottoman.validate(x, function (err) {
       assert.isNull(err);
+      assert.equal(called, true);
     });
   });
 
@@ -751,6 +756,32 @@ describe('Models', function () {
     x.name = 1;
     ottoman.validate(x, function (err) {
       assert.isNotNull(err);
+    });
+  });
+
+  it('should validate a model to all depths', function () {
+    var modelId = H.uniqueId('model');
+    var called = false;
+    var TestMdl = ottoman.model(modelId, {
+      person: {
+        name: {
+          type: 'string',
+          validator: function (value) {
+            if (typeof (value) !== 'string') {
+              throw new Error('bad data');
+            }
+            else {
+              called = true;
+            }
+          }
+        }
+      }
+    });
+
+    var x = new TestMdl({ person: { name: 'Joseph' } });
+    ottoman.validate(x, function (err) {
+      assert.isNull(err);
+      assert.equal(called, true);
     });
   });
 


### PR DESCRIPTION
Currently any validators used in an ottoman schema must be at the root level of a document. Specifying a validator at a lower level - in an ottoman FieldGroup - will not cause this validator to fire. This PR simply adds a unit test to exercise this ability and uses a simple DFS to traverse the fields looking for validators to call. 