### PR TITLE
Return design docs for external usage. E.g. use it in pouchdb.

### DIFF
--- a/lib/cbstoreadapter.js
+++ b/lib/cbstoreadapter.js
@@ -301,7 +301,7 @@ CbStoreAdapter.prototype._ensureMrIndices = function (callback) {
 
     proced++;
     if (proced === ddocs.length) {
-      callback(null);
+      callback(null, ddocs);
       return;
     }
   }
@@ -485,7 +485,7 @@ CbStoreAdapter.prototype.ensureIndices = function (callback) {
 
   var self = this;
 
-  self._ensureMrIndices(function (err) {
+  self._ensureMrIndices(function (err, ddocs) {
     if (err) {
       callback(err);
       return;
@@ -497,7 +497,7 @@ CbStoreAdapter.prototype.ensureIndices = function (callback) {
         return;
       }
 
-      callback(null);
+      callback(null, ddocs);
     });
   });
 };

--- a/lib/ottoman.js
+++ b/lib/ottoman.js
@@ -930,7 +930,7 @@ Ottoman.prototype.ensureIndices = function (callback) {
 
   function _ensureAllStores() {
     var proced = 0;
-    function handler(err) {
+    function handler(err, ddocs) {
       if (err) {
         proced = stores.length;
         callback(err);
@@ -939,7 +939,7 @@ Ottoman.prototype.ensureIndices = function (callback) {
 
       proced++;
       if (proced === stores.length) {
-        callback(null);
+        callback(null, ddocs);
         return;
       }
     }


### PR DESCRIPTION
I'm using pouchdb https://pouchdb.com/ which has simliar design docs. It would be great to reuse the generated ones from ottoman. 

It's just a small change, just giving back some additional data which doesn't change anything in the current API.

My usecase: I have a backend with couchbase and ottoman and a mobile application using pouchdb which I synchronize with Sync Gateway (using shadow bucket). Since the design documents are almost similar I don't have to define the model twice.