### PR TITLE
Promise leak fix

### DIFF
--- a/lib/cbstoreadapter.js
+++ b/lib/cbstoreadapter.js
@@ -452,9 +452,9 @@ CbStoreAdapter.prototype._ensureGsiIndices = function (callback) {
       // Map createIndex across all individual n1ql model indexes.
       // concurrency: 1 is important to avoid overwhelming server.
       // Promise.all turns the array into a single promise again.
-      return Promise.all(Promise.map(queries, function (query) {
+      return Promise.map(queries, function (query) {
         return queryPromise(query);
-      }, { concurrency: 1 }));
+      }, { concurrency: 1 });
     })
     .then(function () {
       // All indexes were built deferred, so now kick off actual build.
@@ -466,7 +466,10 @@ CbStoreAdapter.prototype._ensureGsiIndices = function (callback) {
       return queryPromise(buildEm);
     })
     // If you've gotten this far, everything's good.
-    .then(function () { return callback(null); })
+    .then(function () {
+      callback(null);
+      return null;
+    })
     .catch(function (err) { return callback(err); });
 
   return null;

--- a/lib/schema.js
+++ b/lib/schema.js
@@ -126,14 +126,24 @@ Schema.prototype.namePath = function () {
   return this.context.nsPrefix() + this.name;
 };
 
-//This function is private so the API can run the pre/post handlers
+// This function is private so the API can run the pre/post handlers
 Schema.prototype._validate = function (mdlInst) {
+  // Anything which is a fieldGroup causes a DFS of the trees to validate
+  // any validators which are child elements in the tree
+  var validateTree = function(field, instSubTree) {
+    var current = instSubTree[field.name];
+    if (field.validator) {
+      field.validator(current);
+    } else if (field.type instanceof FieldGroup) { 
+      for (var j = 0; j < field.type.fields.length; ++j) {
+        var child = field.type.fields[j];
+        validateTree(child, current);
+      }
+    }
+  };
   for (var i = 0; i < this.fields.length; ++i) {
     var field = this.fields[i];
-
-    if (field.validator) {
-      field.validator(mdlInst[field.name]);
-    }
+    validateTree(field, mdlInst);
   }
 };
 

--- a/test/basic.test.js
+++ b/test/basic.test.js
@@ -717,12 +717,16 @@ describe('Models', function () {
 
   it('should validate a model', function () {
     var modelId = H.uniqueId('model');
+    var called = false;
     var TestMdl = ottoman.model(modelId, {
       name: {
         type: 'string',
         validator: function (value) {
           if (typeof (value) !== 'string') {
             throw new Error('bad data');
+          }
+          else { 
+            called = true;
           }
         }
       }
@@ -731,6 +735,7 @@ describe('Models', function () {
     var x = new TestMdl({ name: 'Joseph' });
     ottoman.validate(x, function (err) {
       assert.isNull(err);
+      assert.equal(called, true);
     });
   });
 
@@ -751,6 +756,32 @@ describe('Models', function () {
     x.name = 1;
     ottoman.validate(x, function (err) {
       assert.isNotNull(err);
+    });
+  });
+
+  it('should validate a model to all depths', function () {
+    var modelId = H.uniqueId('model');
+    var called = false;
+    var TestMdl = ottoman.model(modelId, {
+      person: {
+        name: {
+          type: 'string',
+          validator: function (value) {
+            if (typeof (value) !== 'string') {
+              throw new Error('bad data');
+            }
+            else {
+              called = true;
+            }
+          }
+        }
+      }
+    });
+
+    var x = new TestMdl({ person: { name: 'Joseph' } });
+    ottoman.validate(x, function (err) {
+      assert.isNull(err);
+      assert.equal(called, true);
     });
   });
 


### PR DESCRIPTION
bluebird is used for promise chaining internally.

In some exotic circumstances, bluebird can get fooled into thinking a promise is getting leaked by this code, when the callback being used introduces other promises.  This was a hard to track down bug for us.

By simply changing the return type to null, any promises in the callback become the caller's responsibility as they should be.

Additionally, one extraneous "Promise.all" is removed.   Promise.map already returns a promise, so the Promise.all is unnecessary.