### PR TITLE
Validator fix

### DIFF
--- a/lib/schema.js
+++ b/lib/schema.js
@@ -126,14 +126,24 @@ Schema.prototype.namePath = function () {
   return this.context.nsPrefix() + this.name;
 };
 
-//This function is private so the API can run the pre/post handlers
+// This function is private so the API can run the pre/post handlers
 Schema.prototype._validate = function (mdlInst) {
+  // Anything which is a fieldGroup causes a DFS of the trees to validate
+  // any validators which are child elements in the tree
+  var validateTree = function(field, instSubTree) {
+    var current = instSubTree[field.name];
+    if (field.validator) {
+      field.validator(current);
+    } else if (field.type instanceof FieldGroup) { 
+      for (var j = 0; j < field.type.fields.length; ++j) {
+        var child = field.type.fields[j];
+        validateTree(child, current);
+      }
+    }
+  };
   for (var i = 0; i < this.fields.length; ++i) {
     var field = this.fields[i];
-
-    if (field.validator) {
-      field.validator(mdlInst[field.name]);
-    }
+    validateTree(field, mdlInst);
   }
 };
 

--- a/lib/schema.js
+++ b/lib/schema.js
@@ -131,7 +131,11 @@ Schema.prototype._validate = function (mdlInst) {
   // Anything which is a fieldGroup causes a DFS of the trees to validate
   // any validators which are child elements in the tree
   var validateTree = function(field, instSubTree) {
-    var current = instSubTree[field.name];
+    var current = null;
+    if(instSubTree){
+      // instance might have a null subtree, but still needs validation
+      current = instSubTree[field.name];
+    }
     if (field.validator) {
       field.validator(current);
     } else if (field.type instanceof FieldGroup) { 

--- a/test/basic.test.js
+++ b/test/basic.test.js
@@ -785,6 +785,56 @@ describe('Models', function () {
     });
   });
 
+  // null subdocs without a validator should pass through unharmed
+  it('should validate a model to all depths unless null subdocs have no validator', function () {
+    var modelId = H.uniqueId('model');
+    var TestMdl = ottoman.model(modelId, {
+      person: {
+        notes: { type: 'string' },
+        info:{
+          name: {
+            type: 'string',
+          }
+        }
+      }
+    });
+    // leaving off the person.info.name bit should be ok in this case
+    var x = new TestMdl({ person: { notes: 'goes by joe'  } });
+    ottoman.validate(x, function (err) {
+      assert.isNull(err);
+    });
+  });
+
+
+
+  // A model instance may have a null subdoc that needs to be validated
+  it('should validate a model to all depths and handle null subdocs', function () {
+    var modelId = H.uniqueId('model');
+    var called = false;
+    var TestMdl = ottoman.model(modelId, {
+      person: {
+        notes: { type: 'string' },
+        info:{
+          name: {
+            type: 'string',
+            validator: function (value) {
+              if (typeof (value) !== 'string') {
+                called = true;
+                throw new Error('bad data');
+              }
+            }
+          }
+        }
+      }
+    });
+    // leaving off the name field is not ok here because info is null
+    var x = new TestMdl({ person: { notes: 'goes by joe'  } });
+    ottoman.validate(x, function (err) {
+      assert.isNotNull(err);
+      assert.equal(called, true);
+    });
+  });
+
 
 
 

--- a/test/basic.test.js
+++ b/test/basic.test.js
@@ -715,7 +715,7 @@ describe('Models', function () {
     assert.equal(x.name, 'Joseph');
   });
 
-  it('should validate a model', function () {
+  it('should validate a model', function (done) {
     var modelId = H.uniqueId('model');
     var called = false;
     var TestMdl = ottoman.model(modelId, {
@@ -736,10 +736,11 @@ describe('Models', function () {
     ottoman.validate(x, function (err) {
       assert.isNull(err);
       assert.equal(called, true);
+      done();
     });
   });
 
-  it('should fail to validate bad data', function () {
+  it('should fail to validate bad data', function (done) {
     var modelId = H.uniqueId('model');
     var TestMdl = ottoman.model(modelId, {
       name: {
@@ -756,10 +757,11 @@ describe('Models', function () {
     x.name = 1;
     ottoman.validate(x, function (err) {
       assert.isNotNull(err);
+      done();
     });
   });
 
-  it('should validate a model to all depths', function () {
+  it('should validate a model to all depths', function (done) {
     var modelId = H.uniqueId('model');
     var called = false;
     var TestMdl = ottoman.model(modelId, {
@@ -782,11 +784,12 @@ describe('Models', function () {
     ottoman.validate(x, function (err) {
       assert.isNull(err);
       assert.equal(called, true);
+      done();
     });
   });
 
   // null subdocs without a validator should pass through unharmed
-  it('should validate a model to all depths unless null subdocs have no validator', function () {
+  it('should validate a model to all depths unless null subdocs have no validator', function (done) {
     var modelId = H.uniqueId('model');
     var TestMdl = ottoman.model(modelId, {
       person: {
@@ -802,13 +805,14 @@ describe('Models', function () {
     var x = new TestMdl({ person: { notes: 'goes by joe'  } });
     ottoman.validate(x, function (err) {
       assert.isNull(err);
+      done();
     });
   });
 
 
 
   // A model instance may have a null subdoc that needs to be validated
-  it('should validate a model to all depths and handle null subdocs', function () {
+  it('should validate a model to all depths and handle null subdocs', function (done) {
     var modelId = H.uniqueId('model');
     var called = false;
     var TestMdl = ottoman.model(modelId, {
@@ -832,6 +836,7 @@ describe('Models', function () {
     ottoman.validate(x, function (err) {
       assert.isNotNull(err);
       assert.equal(called, true);
+      done();
     });
   });
 

--- a/test/basic.test.js
+++ b/test/basic.test.js
@@ -717,12 +717,16 @@ describe('Models', function () {
 
   it('should validate a model', function () {
     var modelId = H.uniqueId('model');
+    var called = false;
     var TestMdl = ottoman.model(modelId, {
       name: {
         type: 'string',
         validator: function (value) {
           if (typeof (value) !== 'string') {
             throw new Error('bad data');
+          }
+          else { 
+            called = true;
           }
         }
       }
@@ -731,6 +735,7 @@ describe('Models', function () {
     var x = new TestMdl({ name: 'Joseph' });
     ottoman.validate(x, function (err) {
       assert.isNull(err);
+      assert.equal(called, true);
     });
   });
 
@@ -751,6 +756,32 @@ describe('Models', function () {
     x.name = 1;
     ottoman.validate(x, function (err) {
       assert.isNotNull(err);
+    });
+  });
+
+  it('should validate a model to all depths', function () {
+    var modelId = H.uniqueId('model');
+    var called = false;
+    var TestMdl = ottoman.model(modelId, {
+      person: {
+        name: {
+          type: 'string',
+          validator: function (value) {
+            if (typeof (value) !== 'string') {
+              throw new Error('bad data');
+            }
+            else {
+              called = true;
+            }
+          }
+        }
+      }
+    });
+
+    var x = new TestMdl({ person: { name: 'Joseph' } });
+    ottoman.validate(x, function (err) {
+      assert.isNull(err);
+      assert.equal(called, true);
     });
   });
 


### PR DESCRIPTION
When applying the validateTree function to a model instance, I ran smack into a foolish edge case that I forgot to account for. This PR addresses this with unit tests exercising the possibilities of model instances and validators: 

* When a validator is on a subtree, and that subtree is not null 
     * The validator is called with the correct value from the instance
* When a validator is on a subtree, and that subtree is null in the instance
    * the validator is called with a null value
* When a vanilla subtree has no validators, and that subtree is null in the instance
    * no error case should result

The main thing to know about this PR is that if you have a validator on a leaf of your schema, your validator **will be called** with the null value if any parent in the tree is null all the way up to the root. 

My sincerest apologies for missing this edge case, let me know if there's anything I might have missed here.