### PR TITLE
Validators need to be checked for any part of a subtree that might be…

### DIFF
--- a/lib/schema.js
+++ b/lib/schema.js
@@ -131,7 +131,11 @@ Schema.prototype._validate = function (mdlInst) {
   // Anything which is a fieldGroup causes a DFS of the trees to validate
   // any validators which are child elements in the tree
   var validateTree = function(field, instSubTree) {
-    var current = instSubTree[field.name];
+    var current = null;
+    if(instSubTree){
+      // instance might have a null subtree, but still needs validation
+      current = instSubTree[field.name];
+    }
     if (field.validator) {
       field.validator(current);
     } else if (field.type instanceof FieldGroup) { 

--- a/test/basic.test.js
+++ b/test/basic.test.js
@@ -715,7 +715,7 @@ describe('Models', function () {
     assert.equal(x.name, 'Joseph');
   });
 
-  it('should validate a model', function () {
+  it('should validate a model', function (done) {
     var modelId = H.uniqueId('model');
     var called = false;
     var TestMdl = ottoman.model(modelId, {
@@ -736,10 +736,11 @@ describe('Models', function () {
     ottoman.validate(x, function (err) {
       assert.isNull(err);
       assert.equal(called, true);
+      done();
     });
   });
 
-  it('should fail to validate bad data', function () {
+  it('should fail to validate bad data', function (done) {
     var modelId = H.uniqueId('model');
     var TestMdl = ottoman.model(modelId, {
       name: {
@@ -756,10 +757,11 @@ describe('Models', function () {
     x.name = 1;
     ottoman.validate(x, function (err) {
       assert.isNotNull(err);
+      done();
     });
   });
 
-  it('should validate a model to all depths', function () {
+  it('should validate a model to all depths', function (done) {
     var modelId = H.uniqueId('model');
     var called = false;
     var TestMdl = ottoman.model(modelId, {
@@ -782,6 +784,59 @@ describe('Models', function () {
     ottoman.validate(x, function (err) {
       assert.isNull(err);
       assert.equal(called, true);
+      done();
+    });
+  });
+
+  // null subdocs without a validator should pass through unharmed
+  it('should validate a model to all depths unless null subdocs have no validator', function (done) {
+    var modelId = H.uniqueId('model');
+    var TestMdl = ottoman.model(modelId, {
+      person: {
+        notes: { type: 'string' },
+        info:{
+          name: {
+            type: 'string',
+          }
+        }
+      }
+    });
+    // leaving off the person.info.name bit should be ok in this case
+    var x = new TestMdl({ person: { notes: 'goes by joe'  } });
+    ottoman.validate(x, function (err) {
+      assert.isNull(err);
+      done();
+    });
+  });
+
+
+
+  // A model instance may have a null subdoc that needs to be validated
+  it('should validate a model to all depths and handle null subdocs', function (done) {
+    var modelId = H.uniqueId('model');
+    var called = false;
+    var TestMdl = ottoman.model(modelId, {
+      person: {
+        notes: { type: 'string' },
+        info:{
+          name: {
+            type: 'string',
+            validator: function (value) {
+              if (typeof (value) !== 'string') {
+                called = true;
+                throw new Error('bad data');
+              }
+            }
+          }
+        }
+      }
+    });
+    // leaving off the name field is not ok here because info is null
+    var x = new TestMdl({ person: { notes: 'goes by joe'  } });
+    ottoman.validate(x, function (err) {
+      assert.isNotNull(err);
+      assert.equal(called, true);
+      done();
     });
   });
 


### PR DESCRIPTION
When applying the validateTree function to a model instance, I ran smack into a foolish edge case that I forgot to account for. This PR addresses this with unit tests exercising the possibilities of model instances and validators:

 * When a validator is on a subtree, and that subtree is not null
    * The validator is called with the correct value from the instance
 * When a validator is on a subtree, and that subtree is null in the instance
    * the validator is called with a null value
 *  When a vanilla subtree has no validators, and that subtree is null in the instance
    * no error case should result  

The main thing to know about this PR is that if you have a validator on a leaf of your schema, your validator will be called with the null value if any parent in the tree is null all the way up to the root.

My sincerest apologies for missing this edge case, let me know if there's anything I might have missed here.