### PR TITLE
update countModels function making options non-required and filters normalised

### DIFF
--- a/lib/modelinstance.js
+++ b/lib/modelinstance.js
@@ -670,7 +670,7 @@ ModelInstance.find = function (filter, options, callback) {
  * @param {Function} callback
  */
 ModelInstance.count = function (filter, options, callback) {
-  this.schema.context._countModels(this, filter, callback);
+  this.schema.context._countModels(this, filter, options, callback);
 };
 
 /**

--- a/lib/ottoman.js
+++ b/lib/ottoman.js
@@ -525,16 +525,26 @@ Ottoman.prototype._findModelByIndex = function (model, index) {
  * @private
  * @ignore
  */
-Ottoman.prototype._countModels = function (model, filter, callback) {
+Ottoman.prototype._countModels = function (model, filter, options, callback) {
   if (filter instanceof Function) {
     callback = filter;
     filter = {};
+  } else if (options instanceof Function) {
+    callback = options;
+    options = {};
   }
 
   var schema = model.schema;
   var mdlName = schema.namePath();
 
-  schema.store.count('n1ql', mdlName, { filter: filter }, function (err, res) {
+  var countOpts = { filter: this._normFilter(filter) };
+  for (var i in options) {
+    if (options.hasOwnProperty(i)) {
+      countOpts[i] = options[i];
+    }
+  }
+
+  schema.store.count('n1ql', mdlName, countOpts, function (err, res) {
     callback(err, res);
   });
 };


### PR DESCRIPTION
this follows the same format as used by _findModels, calling _normFilter to replace loaded Models with unloaded references