### PR TITLE
add $missing to _buildFilterExprs SPECIAL_KEYS for N1QL 'key IS MISSING' queries

### DIFF
--- a/lib/cbstoreadapter.js
+++ b/lib/cbstoreadapter.js
@@ -643,7 +643,7 @@ CbStoreAdapter.prototype.searchIndex =
  * @ignore
  */
 function _buildFilterExprs(filters, expressions, root) {
-  var SPECIAL_KEYS = ['$exists', '$contains'];
+  var SPECIAL_KEYS = ['$exists', '$missing', '$contains'];
   var BOOLEAN = ['or', 'and'];
   if (!root) {
     root = '';
@@ -658,6 +658,9 @@ function _buildFilterExprs(filters, expressions, root) {
       var ident = root + '`' + i.split('.').join('`.`') + '`';
       if (filters[i].$exists) {
         expressions.push(ident + ' IS VALUED');
+      }
+      if (filters[i].$missing) {
+        expressions.push(ident + ' IS MISSING');
       }
       if (filters[i].$contains) {
         var subfilters = filters[i].$contains;


### PR DESCRIPTION
allows Model.find({ key: { $missing: true } }, cb) to find results without the given key