### PR TITLE
When there was the same fields within FieldGroup were not created

### DIFF
--- a/lib/schema.js
+++ b/lib/schema.js
@@ -623,21 +623,31 @@ Schema.prototype.applyUserDataToObject = function (obj, data) {
 };
 
 Schema.prototype.applyDefaultsToObject = function (obj) {
-  for (var i = 0; i < this.fields.length; ++i) {
-    var field = this.fields[i];
-
-    if (field.type instanceof FieldGroup) {
-      obj[field.name] = field.type.create();
-    } else if (field.type instanceof ListField) {
-      obj[field.name] = [];
-    } else {
-      if (field.default instanceof Function) {
-        obj[field.name] = field.default();
-      } else if (field.default !== undefined) {
-        obj[field.name] = field.default;
+  var applyDefaultsToObject = function(_obj, fields) {
+    for (var i = 0; i < fields.length; ++i) {
+      var field = fields[i];
+      if (field.type instanceof FieldGroup) {
+        if (field.type.fields) {
+          _obj[field.name] = applyDefaultsToObject({}, field.type.fields);
+        } else {
+          _obj[field.name] = field.type.create(); 
+        }
+      } else if (field.type instanceof ListField) {
+        _obj[field.name] = [];
+      } else {
+        if (field.default instanceof Function) {
+          _obj[field.name] = field.default();
+        } else 
+        if (field.default !== undefined) {
+          _obj[field.name] = field.default;
+        } else {
+          _obj[field.name] = null;
+        }
       }
     }
-  }
+    return _obj
+  };
+  obj = applyDefaultsToObject(obj, this.fields);
 };
 
 Schema.prototype.applyPropsToObj = function (obj) {


### PR DESCRIPTION
I saw that were not created because it directly called the .Create function, but often want to implement sub-fields into fields. Please check it.

Example

```
var MyModel = db.model("MyModel", { 
    property1: {
        data: 'string',
        userId: 'number', 
    },
    property2: {
        property3: 'string',
        property4: {
            property5: 'string'
        },
        property6: {
            property7: 'number'
        }
    }
});
```
