### PR TITLE
Fix for CREATE INDEX query error

### DIFF
--- a/lib/cbstoreadapter.js
+++ b/lib/cbstoreadapter.js
@@ -445,8 +445,8 @@ CbStoreAdapter.prototype._ensureGsiIndices = function (callback) {
     .then(function () {
       indexes.push('Ottoman__type');
       // Create ottoman type index, needed to make model lookups fast.
-      return queryPromise('CREATE INDEX `Ottoman__type` ON ' +
-        self.bucket._name + '(`_type`) USING GSI WITH {"defer_build": true}');
+      return queryPromise('CREATE INDEX `Ottoman__type` ON `' +
+        self.bucket._name + '`(`_type`) USING GSI WITH {"defer_build": true}');
     })
     .then(function () {
       // Map createIndex across all individual n1ql model indexes.


### PR DESCRIPTION
The bucket name is not being wrapped with ``, causing errors with *all* bucket names. *Edited from: only bucket names with underscores and dashed*

The current #master doesn't seem to work with *any* bucket name. I'm not sure whether couchbase was updated, or what, because this should be causing tests to fail. In my patch-1, `ensureIndices` succeeds with no errors. In the current node-ottoman#master (and 1.0.4 tag), `ensureIndices` is failing from a syntax error during CREATE INDEX.