### PR TITLE
permit nullable dates

### DIFF
--- a/lib/modelinstance.js
+++ b/lib/modelinstance.js
@@ -226,6 +226,10 @@ function _encodeValue(context, type, value, forceTyping, f) {
       '$ref': value.id()
     };
   } else if (type === Schema.DateType) {
+    if (value === null || value === undefined) {
+      return value;
+    }
+
     if (!(value instanceof Date)) {
       // throw new Error('Expected ' + f.name + ' type to be a Date.');
       value = new Date(value);

--- a/lib/modelinstance.js
+++ b/lib/modelinstance.js
@@ -212,18 +212,28 @@ function _encodeValue(context, type, value, forceTyping, f) {
     }
     return outObj;
   } else if (type instanceof Schema.ModelRef) {
-    if (!(value instanceof ModelInstance)) {
-      throw new Error('Expected ' + f.name + ' type to be a ModelInstance.');
+    // Take care to allow for the possibility that value is null.
+    if (value) {
+      if (!(value instanceof ModelInstance)) {
+        throw new Error('Expected ' + f.name + ' type to be a ModelInstance.');
+      }
+      // Values must match stated type names, unless the reference is to
+      // 'Mixed', then any reference will do.
+      if (type.name !== value.$.schema.name && (type.name !== 'Mixed')) {
+        throw new Error('Expected type to be `' +
+          type.name + '` (got `' + value.$.schema.name + '`)');
+      }
+
+      return {
+        '_type': value.$.schema.namePath(),
+        '$ref': value.id()
+      };
     }
-    // Values must match stated type names, unless the reference is to
-    // 'Mixed', then any reference will do.
-    if (type.name !== value.$.schema.name && (type.name !== 'Mixed')) {
-      throw new Error('Expected type to be `' +
-        type.name + '` (got `' + value.$.schema.name + '`)');
-    }
+
+    console.log('REF is falsy with ' + JSON.stringify(type, null, 2));
     return {
-      '_type': value.$.schema.namePath(),
-      '$ref': value.id()
+      '_type': type.name,
+      '$ref': value
     };
   } else if (type === Schema.DateType) {
     if (value === null || value === undefined) {

--- a/lib/schema.js
+++ b/lib/schema.js
@@ -433,6 +433,8 @@ function _fieldTypeSearchWildcard(obj) {
 
 function _decodeValue(context, type, data) {
   if (data instanceof Object && data.$ref) {
+    // It's a populated and specified reference,
+    // e.g. { _type: 'foo', $ref: 'abc-123' }
     if (!(type instanceof ModelRef)) {
       throw new Error(
         'Field looks like a reference, but model does not agree!');
@@ -457,11 +459,21 @@ function _decodeValue(context, type, data) {
 
     return modelType.ref(data.$ref);
   } else if (data instanceof Object && data._type) {
+    // It's a typed reference, but watch out it might
+    // not be specified.
+    // e.g. { _type: 'foo', $ref: null }
+
     if (type === mixedCoreType) {
       type = context.typeByName(data._type);
       if (!type) {
         throw new Error('Could not deduce mixed type from data.');
       }
+    }
+
+    if (!data.$ref) {
+      // Null/undefined cases.  In these cases,
+      // type won't have a fromData function
+      return data.$ref;
     }
 
     return type.fromData(data);
@@ -580,7 +592,8 @@ function _decodeUserValue(context, type, data) {
 
     if (type.name === 'Mixed' || expectedType === Schema.Mixed) {
       // Pass; mixed references are permitted.
-    } else if (!(data instanceof expectedType)) {
+    } else if (data && !(data instanceof expectedType)) {
+      // By requiring data to be truthy, we implicitly allow null/undefined.
       throw new Error('Expected value to be a ModelInstance of type `' +
         type.name + '`.');
     }

--- a/lib/schema.js
+++ b/lib/schema.js
@@ -138,7 +138,7 @@ Schema.prototype._validate = function (mdlInst) {
     }
     if (field.validator) {
       field.validator(current);
-    } else if (field.type instanceof FieldGroup) { 
+    } else if (field.type instanceof FieldGroup) {
       for (var j = 0; j < field.type.fields.length; ++j) {
         var child = field.type.fields[j];
         validateTree(child, current);
@@ -468,6 +468,10 @@ function _decodeValue(context, type, data) {
   } else {
     if (type instanceof CoreType) {
       if (type === dateCoreType) {
+        if (data === null || data === undefined) {
+          return data;
+        }
+
         return new Date(data);
       } else {
         return data;
@@ -540,6 +544,10 @@ function _decodeUserFields(context, fields, obj, data) {
 function _decodeUserValue(context, type, data) {
   if (type instanceof CoreType) {
     if (type === dateCoreType) {
+      if (data === null || data === undefined) {
+        return data;
+      }
+
       return new Date(data);
     } else {
       return data;

--- a/test/basic.test.js
+++ b/test/basic.test.js
@@ -428,6 +428,43 @@ describe('Models', function () {
       assert.equal(xJson.when, x.when.toISOString());
     });
 
+    it('should permit null dates', function () {
+      var modelId = H.uniqueId('model');
+
+      var TestMdl = ottoman.model(modelId, {
+        when: 'Date'
+      });
+
+      var x = new TestMdl();
+      x.when = null;
+      var xJson = x.toCoo();
+
+      assert.equal(xJson.when, null);
+
+      var y = new TestMdl({ when: null });
+      assert.equal(y.when, null);
+    });
+
+    it('should respect default values on dates', function () {
+      var modelId = H.uniqueId('model');
+
+      var val = new Date('2015-01-01');
+
+      var TestMdl = ottoman.model(modelId, {
+        when: { type: 'Date', default: val }
+      });
+
+      var x = new TestMdl();
+      assert.equal(x.when, val);
+
+      var Test2 = ottoman.model(H.uniqueId('model'), {
+        when: { type: 'Date', default: null }
+      });
+
+      var y = new Test2();
+      assert.equal(y.when, null);
+    });
+
     it('should serialize mixed date types properly', function () {
       var modelId = H.uniqueId('model');
 
@@ -615,7 +652,8 @@ describe('Models', function () {
   it('should successfully save and load an object', function (done) {
     var modelId = H.uniqueId('model');
     var TestMdl = ottoman.model(modelId, {
-      name: 'string'
+      name: 'string',
+      when: { type: 'Date', default: null }
     });
 
     var x = new TestMdl();
@@ -631,6 +669,8 @@ describe('Models', function () {
         assert.instanceOf(y, TestMdl);
         assert.equal(x._id, y._id);
         assert.equal(x.name, y.name);
+        assert.equal(x.when, y.when);
+        assert.equal(y.when, null);
         done();
       });
     });
@@ -639,11 +679,15 @@ describe('Models', function () {
   it('should successfully update an object', function (done) {
     var modelId = H.uniqueId('model');
     var TestMdl = ottoman.model(modelId, {
-      name: 'string'
+      name: 'string',
+      when: 'Date',
     });
+
+    var myMoment = new Date();
 
     var x = new TestMdl();
     x.name = 'George';
+    x.when = myMoment;
 
     x.save(function (err) {
       assert.isNull(err);
@@ -655,6 +699,9 @@ describe('Models', function () {
         assert.instanceOf(y, TestMdl);
         assert.equal(x._id, y._id);
         assert.equal(x.name, y.name);
+        assert.notStrictEqual(x.when, y.when);
+        assert.notStrictEqual(y.when, myMoment);
+
         y.name = 'Not George';
         y.save(function (err) {
           assert.isNull(err);
@@ -666,6 +713,7 @@ describe('Models', function () {
             assert.instanceOf(y, TestMdl);
             assert.equal(y._id, z._id);
             assert.equal(y.name, z.name);
+            assert.notStrictEqual(z.when, myMoment);
             done();
           });
         });

--- a/test/model-references.test.js
+++ b/test/model-references.test.js
@@ -112,6 +112,28 @@ describe('Model references', function () {
     });
   });
 
+  it('should allow a reference to be present, but null', function (done) {
+    var nullLinked = new User({
+      username: 'nullAccountLink',
+      account: null
+    });
+
+    nullLinked.save(function (err) {
+      if (err) { return done(err); }
+
+      expect(nullLinked.account).to.be.null;
+
+      User.findByUsername('nullAccountLink', function (err, myUsers) {
+        expect(myUsers).to.be.an('array');
+        expect(myUsers.length).to.equal(1);
+        var user = myUsers[0];
+
+        expect(user.account).to.be.null;
+        done();
+      });
+    })
+  });
+
   it('should permit referencing two models together', function (done) {
     var myAccount = new Account({
       email: 'burtteh@fakemail.com',


### PR DESCRIPTION
This is a fix for this issue:  https://github.com/couchbaselabs/node-ottoman/issues/127

This is a rather serious issue and not a simple enhancement, because ottoman doesn't currently respect the `default` value specified on the model.   Attempts to set a date to null will result in getting January 1, 1970, which is just incorrect.

A serious side effect of this problem is that if a model has a set date, the date can later not be unset.   Suppose you have a database model for a "Task" with a reminder date.  Once the reminder date is established in the model, it is no longer possible to not have one, since attempts to set it to null would reset to 1970.

This PR comes with full unit tests