### PR TITLE
fix creation of GSI indexes

### DIFF
--- a/lib/cbstoreadapter.js
+++ b/lib/cbstoreadapter.js
@@ -357,7 +357,7 @@ CbStoreAdapter.prototype._ensureGsiIndices = function (callback) {
       var indexName =
          i.replace(/[\\$]/g, '__')
           .replace('[*]', '-ALL')
-          .replace('::', '-');
+          .replace(/(::)/g, '-');
       var fieldNames = [];
       for (var j = 0; j < gsi.fields.length; ++j) {
         try {


### PR DESCRIPTION
Change replace to replace with regex because sometimes index name contains two '::'