### PR TITLE
Adds TypeScript type declaration

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,9 +1,8 @@
 language: node_js
 node_js:
-  - "0.10"
-  - "0.12"
   - "4.4"
   - "5.1"
+  - "8.10.0"
 
 # 0.6 is not enabled as couchnode does not support
 #   this particular version of Node.js.

--- a/README.md
+++ b/README.md
@@ -100,9 +100,9 @@ var Furniture = ottoman.model('Furniture', {
 });
 ```
 
-Now we need to ensure that this index is available on the server for searching:
+Now we need to ensure that this index is available on the server for searching (1st param to `ensureIndices` enables or disables [deferred index building](https://blog.couchbase.com/deferring-of-index-creation/)):
 ```javascript
-ottoman.ensureIndices(function(err) {
+ottoman.ensureIndices(true, function(err) {
   if (err) return console.error(err);
 });
 ```
@@ -280,10 +280,12 @@ ottoman.model('User', {
 
 In order for indices to be created on the server, you must call the `ensureIndices` method.  This method will internally generate a list of indexes which will be used and the most optimal configuration for them and build any which are missing on the server.  This must be called after all models are defined, and it is a good idea to only call this when needed rather than any time your server is started.
 
+The 1st parameter passed to `ensureIndices` enables or disables [deferred index building](https://blog.couchbase.com/deferring-of-index-creation/).
+
 ```javascript
 var ottoman = require('ottoman');
 var models = require('./all_my_models');
-ottoman.ensureIndices(function(err) {
+ottoman.ensureIndices(true, function(err) {
   if (err) {
     console.log('failed to created necessary indices', err);
     return;

--- a/index.d.ts
+++ b/index.d.ts
@@ -3,65 +3,67 @@
 import { Bucket, CouchbaseError  } from "couchbase";
 
 declare namespace OttomanJS {
-    class StoreAdapter {
-        constructor(bucket: Bucket)
-    }
+  class StoreAdapter {
+    constructor (bucket: Bucket)
+    store (key: string, data: object, cas: object, callback: any): any
+  }
 
-    interface Model {
-    }
+  class CbStoreAdapter {
+    constructor (bucket: Bucket)
+    store (key: string, data: object, cas: object, callback: any): any
+  }
 
-    interface TypeDef {
-    }
+  interface Model {
+  }
 
-    interface OttomanOptions {
-        bucket?: Bucket
-        store?: StoreAdapter
-        namespace?: string
-    }
+  interface TypeDef {
+  }
 
-    interface Schema {
+  interface OttomanOptions {
+    bucket?: Bucket
+    store?: StoreAdapter
+    namespace?: string
+  }
 
-    }
+  interface Schema {
 
-    interface Indices {
-    }
+  }
 
-    interface GetByIdOptions {
-    }
+  interface Indices {
+  }
 
-    interface CreateOptions {
-    }
+  interface GetByIdOptions {
+  }
 
-    type CreateCallback = (error: CouchbaseError | null, document: ModelInstance | undefined) => void
+  interface CreateOptions {
+  }
+
+  type CreateCallback = (error: CouchbaseError | null, document: ModelInstance | undefined) => void
     type GetByIdCallback = (error: CouchbaseError | null, model: ModelInstance | undefined) => void
     type SaveCallback = (error: CouchbaseError | null, response: ModelInstance | undefined) => void
 
     export interface ModelInstance {
-        save (callback: SaveCallback): void
+      save (callback: SaveCallback): void
     }
 
-    interface Model {
-        getById (id: string, options: GetByIdOptions | undefined, callback: GetByIdCallback): void
-        create (id: object, options: CreateOptions | undefined, callback: CreateCallback): void
-    }
+  interface Model {
+    getById (id: string, options: GetByIdOptions | undefined, callback: GetByIdCallback): void
+    create (id: object, callback: CreateCallback): void
+  }
 
-    class Ottoman {
-        bucket: Bucket
-        readonly namespace: string
-        readonly store: StoreAdapter
-        readonly models: { [key: string]: Model }
-        readonly types: { [key: string]: TypeDef | undefined }
-        readonly delayedBind: { [key: string]: Function | undefined }
-        readonly plugins: Array<[Function, object]>
+  class Ottoman {
+    bucket: Bucket
+    readonly namespace: string
+    readonly store: StoreAdapter
+    readonly models: { [key: string]: Model }
+    readonly types: { [key: string]: TypeDef | undefined }
+    readonly delayedBind: { [key: string]: Function | undefined }
+    readonly plugins: Array<[Function, object]>
 
-        constructor (options: OttomanOptions)
+    constructor (options: OttomanOptions)
 
-        model(key: string, schema: Schema, index: Indices): Model
-    }
+    model (key: string, schema: Schema, index: Indices): Model
+  }
 }
 
-declare module 'ottoman' {
-    // bucket and model intentionally not exposed (singletons are baaaaad.)
-    let Ottoman: OttomanJS.Ottoman
-    let StoreAdapter: OttomanJS.StoreAdapter
-}
+export = OttomanJS

--- a/index.d.ts
+++ b/index.d.ts
@@ -22,9 +22,13 @@ declare namespace OttomanJS {
     namespace?: string
   }
 
+  interface ModelReference {
+    ref: string
+  }
+
   type ValidatorFunction = (value: any) => void
   interface SchemaField {
-    type: 'string' | 'number' | 'integer' | 'boolean' | 'Date' | 'mixed',
+    type: 'string' | 'number' | 'integer' | 'boolean' | 'Date' | 'mixed' | ModelReference,
     auto: 'uuid',
     readonly: boolean,
     validator: ValidatorFunction
@@ -38,7 +42,13 @@ declare namespace OttomanJS {
     validate<T> (modelInstance: ModelInstance<T>, callback: ValidationCallback<T>): void
   }
 
-  interface Indices {
+  interface Index {
+    type: 'refdoc' | 'view' | 'n1ql',
+    by: string
+  }
+
+  interface IndexDefinition {
+    [key: string]: Partial<Index>
   }
 
   interface GetByIdOptions {
@@ -74,7 +84,7 @@ declare namespace OttomanJS {
 
     constructor (options: OttomanOptions)
 
-    model (key: string, schema: SchemaDefinition, index: Indices): ModelInstanceCtor
+    model (key: string, schema: SchemaDefinition, index: IndexDefinition): ModelInstanceCtor
   }
 }
 

--- a/index.d.ts
+++ b/index.d.ts
@@ -1,0 +1,67 @@
+/// <reference types="couchbase" />
+
+import { Bucket, CouchbaseError  } from "couchbase";
+
+declare namespace OttomanJS {
+    class StoreAdapter {
+        constructor(bucket: Bucket)
+    }
+
+    interface Model {
+    }
+
+    interface TypeDef {
+    }
+
+    interface OttomanOptions {
+        bucket?: Bucket
+        store?: StoreAdapter
+        namespace?: string
+    }
+
+    interface Schema {
+
+    }
+
+    interface Indices {
+    }
+
+    interface GetByIdOptions {
+    }
+
+    interface CreateOptions {
+    }
+
+    type CreateCallback = (error: CouchbaseError | null, document: ModelInstance | undefined) => void
+    type GetByIdCallback = (error: CouchbaseError | null, model: ModelInstance | undefined) => void
+    type SaveCallback = (error: CouchbaseError | null, response: ModelInstance | undefined) => void
+
+    export interface ModelInstance {
+        save (callback: SaveCallback): void
+    }
+
+    interface Model {
+        getById (id: string, options: GetByIdOptions | undefined, callback: GetByIdCallback): void
+        create (id: object, options: CreateOptions | undefined, callback: CreateCallback): void
+    }
+
+    class Ottoman {
+        bucket: Bucket
+        readonly namespace: string
+        readonly store: StoreAdapter
+        readonly models: { [key: string]: Model }
+        readonly types: { [key: string]: TypeDef | undefined }
+        readonly delayedBind: { [key: string]: Function | undefined }
+        readonly plugins: Array<[Function, object]>
+
+        constructor (options: OttomanOptions)
+
+        model(key: string, schema: Schema, index: Indices): Model
+    }
+}
+
+declare module 'ottoman' {
+    // bucket and model intentionally not exposed (singletons are baaaaad.)
+    let Ottoman: OttomanJS.Ottoman
+    let StoreAdapter: OttomanJS.StoreAdapter
+}

--- a/index.d.ts
+++ b/index.d.ts
@@ -26,6 +26,10 @@ declare namespace OttomanJS {
 
   }
 
+  interface ModelSchema {
+    validate<T> (mdlInst: T, callback: ValidateCallback<T>): void
+  }
+
   interface Indices {
   }
 
@@ -38,12 +42,15 @@ declare namespace OttomanJS {
   type CreateCallback<T> = (error: CouchbaseError | null, document: ModelInstance<T> | undefined) => void
   type GetByIdCallback<T> = (error: CouchbaseError | null, model: ModelInstance<T> | undefined) => void
   type SaveCallback<T> = (error: CouchbaseError | null, response: ModelInstance<T> | undefined) => void
+  type ValidateCallback<T> = (error: CouchbaseError | null) => void
 
   class ModelInstance<T> {
+    constructor(data: any)
     fromData<T> (data: any): T
     getById<T> (id: string, callback: GetByIdCallback<T>): void
     create<T> (data: any, callback: CreateCallback<T>): void
     save (callback: SaveCallback<T>): void
+    schema: ModelSchema
   }
 
   interface ModelInstanceCtor {

--- a/index.d.ts
+++ b/index.d.ts
@@ -43,6 +43,20 @@ declare namespace OttomanJS {
     validate<T> (modelInstance: ModelInstance<T>, callback: ValidationCallback<T>): void
   }
 
+  interface ModelOptions {
+    index?: IndexDefinition
+    query?: QueryDefinition
+  }
+
+  interface Query {
+    of: string
+    by: string
+  }
+
+  interface QueryDefinition {
+    [key: string]: Query
+  }
+
   interface Index {
     type: 'refdoc' | 'view' | 'n1ql',
     by: string
@@ -85,7 +99,7 @@ declare namespace OttomanJS {
 
     constructor (options: OttomanOptions)
 
-    model (key: string, schema: SchemaDefinition, index: IndexDefinition): ModelInstanceCtor
+    model (key: string, schema: SchemaDefinition, options: ModelOptions): ModelInstanceCtor
   }
 }
 

--- a/index.d.ts
+++ b/index.d.ts
@@ -45,10 +45,10 @@ declare namespace OttomanJS {
     getById<T> (id: string, callback: GetByIdCallback<T>): void
     create<T> (data: any, callback: CreateCallback<T>): void
     save (callback: SaveCallback<T>): void
-    schema: Schema
   }
 
   interface ModelInstanceCtor {
+    schema: Schema
   }
 
   class Ottoman {

--- a/index.d.ts
+++ b/index.d.ts
@@ -23,11 +23,7 @@ declare namespace OttomanJS {
   }
 
   interface Schema {
-
-  }
-
-  interface ModelSchema {
-    validate<T> (mdlInst: T, callback: ValidateCallback<T>): void
+    validate<T> (modelInstance: ModelInstance<T>, callback: ValidationCallback<T>): void
   }
 
   interface Indices {
@@ -42,14 +38,14 @@ declare namespace OttomanJS {
   type CreateCallback<T> = (error: CouchbaseError | null, document: ModelInstance<T> | undefined) => void
   type GetByIdCallback<T> = (error: CouchbaseError | null, model: ModelInstance<T> | undefined) => void
   type SaveCallback<T> = (error: CouchbaseError | null, response: ModelInstance<T> | undefined) => void
-  type ValidateCallback<T> = (error: CouchbaseError | null) => void
+  type ValidationCallback<T> = (error: CouchbaseError | null) => void
 
   class ModelInstance<T> {
     fromData<T> (data: any): T
     getById<T> (id: string, callback: GetByIdCallback<T>): void
     create<T> (data: any, callback: CreateCallback<T>): void
     save (callback: SaveCallback<T>): void
-    schema: ModelSchema
+    schema: Schema
   }
 
   interface ModelInstanceCtor {

--- a/index.d.ts
+++ b/index.d.ts
@@ -28,7 +28,7 @@ declare namespace OttomanJS {
 
   type ValidatorFunction = (value: any) => void
   interface SchemaField {
-    type: 'string' | 'number' | 'integer' | 'boolean' | 'Date' | 'mixed' | ModelReference,
+    type: 'string' | 'number' | 'integer' | 'boolean' | 'Date' | 'Mixed' | ModelReference,
     auto: 'uuid',
     readonly: boolean,
     validator: ValidatorFunction,

--- a/index.d.ts
+++ b/index.d.ts
@@ -45,7 +45,6 @@ declare namespace OttomanJS {
   type ValidateCallback<T> = (error: CouchbaseError | null) => void
 
   class ModelInstance<T> {
-    constructor(data: any)
     fromData<T> (data: any): T
     getById<T> (id: string, callback: GetByIdCallback<T>): void
     create<T> (data: any, callback: CreateCallback<T>): void

--- a/index.d.ts
+++ b/index.d.ts
@@ -76,6 +76,7 @@ declare namespace OttomanJS {
   type GetByIdCallback<T> = (error: CouchbaseError | null, model: ModelInstance<T> | undefined) => void
   type SaveCallback<T> = (error: CouchbaseError | null, response: ModelInstance<T> | undefined) => void
   type ValidationCallback<T> = (error: CouchbaseError | null) => void
+  type EnsureIndicesCallback = (error: CouchbaseError | null) => void
 
   class ModelInstance<T> {
     fromData<T> (data: any): T
@@ -100,6 +101,7 @@ declare namespace OttomanJS {
     constructor (options: OttomanOptions)
 
     model (key: string, schema: SchemaDefinition, options: ModelOptions): ModelInstanceCtor
+    ensureIndices (DeferBuild: boolean, callback: Function): void
   }
 }
 

--- a/index.d.ts
+++ b/index.d.ts
@@ -24,7 +24,7 @@ declare namespace OttomanJS {
 
   type ValidatorFunction = (value: any) => void
   interface SchemaField {
-    type: 'string' | 'number' | 'integer' | 'boolean' | 'Date', 'mixed',
+    type: 'string' | 'number' | 'integer' | 'boolean' | 'Date' | 'mixed',
     auto: 'uuid',
     readonly: boolean,
     validator: ValidatorFunction

--- a/index.d.ts
+++ b/index.d.ts
@@ -22,6 +22,18 @@ declare namespace OttomanJS {
     namespace?: string
   }
 
+  type ValidatorFunction = (value: any) => void
+  interface SchemaField {
+    type: 'string' | 'number' | 'integer' | 'boolean' | 'Date', 'mixed',
+    auto: 'uuid',
+    readonly: boolean,
+    validator: ValidatorFunction
+  }
+
+  interface SchemaDefinition {
+    [key: string]: Partial<SchemaField>
+  }
+
   interface Schema {
     validate<T> (modelInstance: ModelInstance<T>, callback: ValidationCallback<T>): void
   }
@@ -62,7 +74,7 @@ declare namespace OttomanJS {
 
     constructor (options: OttomanOptions)
 
-    model (key: string, schema: Schema, index: Indices): ModelInstanceCtor
+    model (key: string, schema: SchemaDefinition, index: Indices): ModelInstanceCtor
   }
 }
 

--- a/lib/cbstoreadapter.js
+++ b/lib/cbstoreadapter.js
@@ -340,7 +340,7 @@ function _ottopathToN1qlPath(path) {
  * @private
  * @ignore
  */
-CbStoreAdapter.prototype._ensureGsiIndices = function (callback) {
+CbStoreAdapter.prototype._ensureGsiIndices = function (deferBuild, callback) {
   var queries = [];
   var indexes = [];
 
@@ -405,7 +405,7 @@ CbStoreAdapter.prototype._ensureGsiIndices = function (callback) {
         fieldNames.join(',') +
         ') ' +
         'WHERE _type="' + gsi.modelName + '" ' +
-        'USING GSI WITH {\"defer_build\": true}');
+        'USING GSI WITH {\"defer_build\": ' + deferBuild + '}');
 
       // Keep track of all indexes we are creating, so we can
       // build them later.
@@ -446,7 +446,7 @@ CbStoreAdapter.prototype._ensureGsiIndices = function (callback) {
       indexes.push('Ottoman__type');
       // Create ottoman type index, needed to make model lookups fast.
       return queryPromise('CREATE INDEX `Ottoman__type` ON `' +
-        self.bucket._name + '`(`_type`) USING GSI WITH {"defer_build": true}');
+        self.bucket._name + '`(`_type`) USING GSI WITH {"defer_build": ' + deferBuild + '}');
     })
     .then(function () {
       // Map createIndex across all individual n1ql model indexes.
@@ -481,7 +481,7 @@ CbStoreAdapter.prototype._ensureGsiIndices = function (callback) {
  *
  * @param {StoreAdapter~EnsureCallback} callback
  */
-CbStoreAdapter.prototype.ensureIndices = function (callback) {
+CbStoreAdapter.prototype.ensureIndices = function (deferBuild, callback) {
   if (this.debug) {
     console.log('CbStoreAdapter::ensureIndices');
   }
@@ -494,7 +494,7 @@ CbStoreAdapter.prototype.ensureIndices = function (callback) {
       return;
     }
 
-    self._ensureGsiIndices(function (err) {
+    self._ensureGsiIndices(deferBuild, function (err) {
       if (err) {
         callback(err);
         return;

--- a/lib/cbstoreadapter.js
+++ b/lib/cbstoreadapter.js
@@ -29,12 +29,6 @@ function CbStoreAdapter(bucket, cb) {
       throw new Error('You must explicitly specify a couchbase module as' +
         ' ottoman was installed without a couchbase dependancy.');
     }
-    if (!(bucket instanceof builtinCouchbase.BucketImpl)) {
-      throw new Error('The couchbase module version used by the application'
-        + ' does not match Ottomans.  Please explicitly pass the application'
-        + ' couchbase module using `StoreAdapter.Couchbase`.');
-    }
-
     cb = builtinCouchbase;
   }
 

--- a/lib/cbstoreadapter.js
+++ b/lib/cbstoreadapter.js
@@ -355,7 +355,7 @@ CbStoreAdapter.prototype._ensureGsiIndices = function (callback) {
       var gsi = this.gsis[i];
 
       var indexName =
-         i.replace('/[\\$]/g', '__')
+         i.replace(/[\\$]/g, '__')
           .replace('[*]', '-ALL')
           .replace('::', '-');
       var fieldNames = [];

--- a/lib/cbstoreadapter.js
+++ b/lib/cbstoreadapter.js
@@ -357,7 +357,7 @@ CbStoreAdapter.prototype._ensureGsiIndices = function (callback) {
       var indexName =
          i.replace(/[\\$]/g, '__')
           .replace('[*]', '-ALL')
-          .replace('::', '-');
+          .replace(/(::)/g, '-');
       var fieldNames = [];
       for (var j = 0; j < gsi.fields.length; ++j) {
         try {

--- a/lib/ottoman.js
+++ b/lib/ottoman.js
@@ -918,7 +918,7 @@ Ottoman.prototype._ensureModelIndices = function (model, callback) {
  *
  * @param {Function} callback
  */
-Ottoman.prototype.ensureIndices = function (callback) {
+Ottoman.prototype.ensureIndices = function (deferBuild, callback) {
   var self = this;
 
   var models = [];
@@ -954,7 +954,7 @@ Ottoman.prototype.ensureIndices = function (callback) {
       }
     }
     for (var i = 0; i < stores.length; ++i) {
-      stores[i].ensureIndices(handler);
+      stores[i].ensureIndices(deferBuild, handler);
     }
   }
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,0 +1,23 @@
+{
+  "name": "ottoman",
+  "version": "1.0.4",
+  "lockfileVersion": 1,
+  "requires": true,
+  "dependencies": {
+    "@types/couchbase": {
+      "version": "2.1.30",
+      "resolved": "https://registry.npmjs.org/@types/couchbase/-/couchbase-2.1.30.tgz",
+      "integrity": "sha1-jYrSth0f5Ehs397N5jDnxmTThZs=",
+      "dev": true,
+      "requires": {
+        "@types/node": "9.4.5"
+      }
+    },
+    "@types/node": {
+      "version": "9.4.5",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-9.4.5.tgz",
+      "integrity": "sha512-DvC7bzO5797bkApgukxouHmkOdYN2D0yL5olw0RncDpXUa6n39qTVsUi/5g2QJjPgl8qn4zh+4h0sofNoWGLRg==",
+      "dev": true
+    }
+  }
+}

--- a/package.json
+++ b/package.json
@@ -25,7 +25,7 @@
     "couchbase": "~2.4.1"
   },
   "devDependencies": {
-    "@types/couchbase": "^2.1.30",
+    "@types/couchbase": "^2.4.1",
     "chai": "~3.3.0",
     "eslint": "^2.9.0",
     "ink-docstrap": "git+https://github.com/brett19/docstrap.git#master",

--- a/package.json
+++ b/package.json
@@ -10,6 +10,7 @@
   "main": "./lib/ottoman",
   "license": "Apache2",
   "name": "ottoman",
+  "types": "index.d.ts",
   "scripts": {
     "test": "eslint ./lib && istanbul cover ./node_modules/mocha/bin/_mocha -- test/*.test.js"
   },
@@ -24,6 +25,7 @@
     "couchbase": "~2.4.1"
   },
   "devDependencies": {
+    "@types/couchbase": "^2.1.30",
     "chai": "~3.3.0",
     "eslint": "^2.9.0",
     "ink-docstrap": "git+https://github.com/brett19/docstrap.git#master",

--- a/package.json
+++ b/package.json
@@ -21,7 +21,7 @@
     "uuid": "~2.0.1"
   },
   "optionalDependencies": {
-    "couchbase": "~2.3.0"
+    "couchbase": "~2.4.1"
   },
   "devDependencies": {
     "chai": "~3.3.0",

--- a/test/indexes.test.js
+++ b/test/indexes.test.js
@@ -30,7 +30,7 @@ describe('Model Indexes', function () {
         }
       });
 
-    ottoman.ensureIndices(function (err) {
+    ottoman.ensureIndices(true, function (err) {
       assert.isNull(err);
 
       var x = new TestMdl();
@@ -124,7 +124,7 @@ describe('Model Indexes', function () {
         }
       });
 
-    ottoman.ensureIndices(function (err) {
+    ottoman.ensureIndices(true, function (err) {
       assert.isNull(err);
 
       var x = new TestMdl();
@@ -162,7 +162,7 @@ describe('Model Indexes', function () {
           }
         });
 
-      ottoman.ensureIndices(function (err) {
+      ottoman.ensureIndices(true, function (err) {
         assert.isNull(err);
 
         var x = new TestMdl();
@@ -202,7 +202,7 @@ describe('Model Indexes', function () {
         }
       });
 
-    ottoman.ensureIndices(function (err) {
+    ottoman.ensureIndices(true, function (err) {
       assert.isNull(err);
 
       var x = new TestMdl();
@@ -241,7 +241,7 @@ describe('Model Indexes', function () {
         }
       });
 
-    ottoman.ensureIndices(function (err) {
+    ottoman.ensureIndices(true, function (err) {
       assert.isNull(err);
 
       var x = new TestMdl();
@@ -288,7 +288,7 @@ describe('Model Indexes', function () {
         }
       });
 
-    ottoman.ensureIndices(function (err) {
+    ottoman.ensureIndices(true, function (err) {
       assert.isNull(err);
 
       var x = new TestMdl();
@@ -325,7 +325,7 @@ describe('Model Indexes', function () {
         }
       });
 
-    ottoX.ensureIndices(function (err) {
+    ottoX.ensureIndices(true, function (err) {
       assert.isNotNull(err);
       done();
     });

--- a/test/instances.test.js
+++ b/test/instances.test.js
@@ -13,7 +13,7 @@ describe('Model Instances', function () {
   var testInstance = new TestMdl({ name: 'Joe Blow' });
 
   before (function (done) {
-    ottoman.ensureIndices(function (err) {
+    ottoman.ensureIndices(true, function (err) {
       if (err) { return done(err); }
 
       // Guarantee at least one saved.

--- a/test/model-references.test.js
+++ b/test/model-references.test.js
@@ -45,7 +45,7 @@ describe('Model references', function () {
     });
 
   before(function (done) {
-    ottoman.ensureIndices(function (err) {
+    ottoman.ensureIndices(true, function (err) {
       if (err) { return done(err); }
       setTimeout(function () { done(); }, 2000);
     });

--- a/test/queries.test.js
+++ b/test/queries.test.js
@@ -28,7 +28,7 @@ describe('Model Queries', function () {
       msg: 'string'
     });
 
-    ottoman.ensureIndices(function (err) {
+    ottoman.ensureIndices(true, function (err) {
       assert.isNull(err);
 
       var ux = new UserMdl();
@@ -104,7 +104,7 @@ describe('Model Queries', function () {
           }
         });
 
-      ottoman.ensureIndices(function (err) {
+      ottoman.ensureIndices(true, function (err) {
         assert.isNull(err);
 
         // Let index creation catch up.


### PR DESCRIPTION
Adds TypeScript type declarations as an index.d.ts. The types are by no means a complete set, but they're getting to a stage where they may be of use also to others (see #188).

One omission is intentional: the ottoman singleton-like instance included in the module exports is intentionally not included, because using it in a TS based program quickly leads into trouble.