### PR TITLE
readme installation instruction correction

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,8 +36,7 @@ An ODM allows developers to:
 
 ### Installing
 
-Ottoman is not yet published to npm, to install the development version
-directly from GitHub, run:
+Ottoman is published to npm, to install it in the project, run:
 ```
 npm install ottoman
 ```


### PR DESCRIPTION
As the instruction written to install ottoman is right but there is mentioned that `ottoman` is not yet published to `npm` which I think is not write because it is already available to `npm` that's why we are able to install it using the command `npm install ottoman`.