### PR TITLE
Replaced INSERT method with UPSERT

### DIFF
--- a/lib/cbstoreadapter.js
+++ b/lib/cbstoreadapter.js
@@ -104,7 +104,7 @@ CbStoreAdapter.prototype.store = function (key, data, cas, callback) {
   if (cas) {
     this.bucket.replace(key, data, { cas: cas }, saveHandler);
   } else {
-    this.bucket.insert(key, data, {}, saveHandler);
+    this.bucket.upsert(key, data, {}, saveHandler);
   }
 };
 


### PR DESCRIPTION
In some more complex project where we save document data not only in Couchbase but in some in-memory database.
If we try to make an update to that information the first think we do is try to reach the document from the in-memory database, edit the JSON, create a new instance of the ottoman model with the new data and save it. Of course, if we do that we will get the CAS key error..

"The key already exists in the server. If you have supplied a CAS then the key exists with a CAS value different than specified"

So that makes the ottoman unusable for a big scaled project that not only saves information in Couchbase.

A simple change of the insert method with upsert will solve our pains.