### PR TITLE
Fix schema.js instanceof vs typeof

### DIFF
--- a/lib/schema.js
+++ b/lib/schema.js
@@ -486,7 +486,7 @@ function _decodeValue(context, type, data) {
       }
       return outArr;
     } else if (type instanceof FieldGroup) {
-      if (!(data instanceof Object)) {
+      if (!(typeof data === 'object')) {
         throw new Error(
           'Encountered a group field, but the data does not agree!');
       }


### PR DESCRIPTION
Was running into issues where data would be _an_ object, but would not have the Object prototype, so the instanceof check would fail.