### PR TITLE
Add Support for Mixed Type and Update Schema Type documentation

### DIFF
--- a/__test__/schema.complex.types.spec.ts
+++ b/__test__/schema.complex.types.spec.ts
@@ -1,4 +1,5 @@
 import { validate, ValidationError, BuildSchemaError, Schema, IOttomanType, registerType } from '../src';
+import { MixedType } from '../src/schema/types';
 
 describe('Schema Types', () => {
   describe('Schema Array Types', () => {
@@ -307,6 +308,88 @@ describe('Schema Types', () => {
         cat: { type: CatSchema, ref: 'Cat' },
       });
       expect(() => validate(data, UserSchema2)).toThrow(new ValidationError('Required!'));
+    });
+  });
+  describe('Schema Mixed Type', () => {
+    test('Check Mixed Schema Type Variants', () => {
+      const UserSchema = new Schema({
+        inline: Schema.Types.Mixed,
+        type: { type: Schema.Types.Mixed, required: true },
+        any: Object,
+        other: {},
+      });
+      const data = {
+        inline: { name: 'george' },
+        type: {
+          email: 'george@gmail.com',
+        },
+        any: 'Hello',
+        other: { hello: 'hello' },
+      };
+
+      expect(validate(data, UserSchema)).toEqual(data);
+    });
+
+    test('Check Mixed Schema Type Variants if is MixedType', () => {
+      const UserSchema = new Schema({
+        inline: Schema.Types.Mixed,
+        type: { type: Schema.Types.Mixed, required: true },
+        any: Object,
+        other: {},
+      });
+
+      expect(UserSchema.fields.inline).toBeInstanceOf(MixedType);
+    });
+
+    test('Check Mixed Schema Type required validation', () => {
+      const UserSchema = new Schema({
+        type: { type: Schema.Types.Mixed, required: true },
+        any: Object,
+      });
+      const data = {
+        any: 'Hello',
+      };
+      const run = () => validate(data, UserSchema);
+      expect(run).toThrow('Property type is required');
+    });
+
+    test('Check Mixed Schema Type custom validation', () => {
+      const validator = (val) => {
+        if (!val.hasOwnProperty('hello')) {
+          throw new Error('Property "hello" is required');
+        }
+      };
+      const UserSchema = new Schema({
+        type: { type: Schema.Types.Mixed, validator },
+      });
+      const data = {
+        type: { helio: 'helio' },
+      };
+      const run = () => validate(data, UserSchema);
+      expect(run).toThrow('Property "hello" is required');
+    });
+  });
+  describe('Test internal Ottoman Schema Types', () => {
+    test('Check Basic Internal Types', () => {
+      const CustomSchema = new Schema({
+        number: Schema.Types.Number,
+        string: Schema.Types.String,
+        array: [Schema.Types.Number],
+        date: Schema.Types.Date,
+        boolean: Schema.Types.Boolean,
+        mixed: { type: Schema.Types.Mixed },
+      });
+
+      const data = {
+        number: 10,
+        string: 'hello',
+        date: new Date(),
+        array: [1, 2, 3],
+        boolean: false,
+        mixed: { hello: 'hello' },
+      };
+
+      expect(validate(data, CustomSchema)).toEqual(data);
     });
   });
 });

--- a/__test__/schema.types.spec.ts
+++ b/__test__/schema.types.spec.ts
@@ -178,7 +178,7 @@ describe('Schema Types', () => {
       age: { type: Number, intVal: true },
       amount: { min: 23, max: 24 },
     };
-    expect(() => new Schema(schema)).toThrow(new BuildSchemaError('Property min is a required type'));
+    expect(() => new Schema(schema)).toThrow(new BuildSchemaError('Unsupported type specified in the property "min"'));
 
     const schemaWithNull = {
       name: String,

--- a/src/schema/helpers/fn-schema.ts
+++ b/src/schema/helpers/fn-schema.ts
@@ -78,10 +78,21 @@ const _parseType = (value, strict = true): ParseResult => {
   }
 };
 
+/**
+ * Create the Structure of schema object.
+ * @private
+ * @param type of the field
+ * @param options of the schema
+ * */
 const _makeParseResult = (type: string, options): ParseResult => {
   return { type, options };
 };
 
+/**
+ * Get the string type of a field
+ * @private
+ * @param type of the field
+ * */
 const _getFieldType = (type: any): any => {
   if (type) {
     return type.name || type.constructor['sName'] || undefined;
@@ -94,6 +105,7 @@ const _getFieldType = (type: any): any => {
  * @private
  * @param name of the field
  * @param def result of parsing the field schema
+ * @throws BuildSchemaError
  */
 const _makeField = (name: string, def: ParseResult): IOttomanType => {
   const typeFactory = Schema.FactoryTypes[String(def.type)];

--- a/src/schema/index.ts
+++ b/src/schema/index.ts
@@ -1,5 +1,5 @@
 export { validate, applyDefaultValue, buildFields, registerType, addValidators } from './helpers';
 export { ValidationError, BuildSchemaError } from './errors';
-export { ReferenceType } from './types';
+export { ReferenceType, MixedType } from './types';
 export { Schema } from './schema';
 export { IOttomanType } from './interfaces/schema.types';

--- a/src/schema/interfaces/schema.types.ts
+++ b/src/schema/interfaces/schema.types.ts
@@ -1,4 +1,5 @@
 import { HOOKS } from '../../utils/hooks';
+import { CoreType } from '../types';
 import { CAST_STRATEGY } from '../../utils/cast-strategy';
 
 export type SchemaDef = Record<string, any>;
@@ -8,9 +9,11 @@ export type FactoryFunction = (name, options) => IOttomanType;
 /**
  * Should throw all errors detected
  */
+export type OttomanSchemaTypes = 'String' | 'Boolean' | 'Number' | 'Date' | 'Array' | 'Reference' | 'Embed' | 'Mixed';
 export type ValidatorFunction = (value: unknown) => void;
 export type AutoFunction = () => unknown;
-export type SupportType = { [key: string]: FactoryFunction };
+export type SupportFactoryTypes = { [key in OttomanSchemaTypes]: FactoryFunction };
+export type SupportTypes = { [key in OttomanSchemaTypes]: CoreType };
 export type CustomValidations = { [key: string]: ValidatorFunction };
 export type RequiredFunction = () => boolean | RequiredOption;
 export type HookHandler = (IDocument) => void;

--- a/src/schema/schema.ts
+++ b/src/schema/schema.ts
@@ -7,6 +7,15 @@ import {
   numberTypeFactory,
   referenceTypeFactory,
   stringTypeFactory,
+  mixedTypeFactory,
+  EmbedType,
+  ArrayType,
+  DateType,
+  NumberType,
+  BooleanType,
+  StringType,
+  MixedType,
+  ReferenceType,
 } from './types';
 import { BuildSchemaError } from './errors';
 import { SchemaIndex, SchemaQuery } from '../model/index/types/index.types';
@@ -20,13 +29,14 @@ import {
   PluginConstructor,
   SchemaDef,
   SchemaOptions,
-  SupportType,
+  SupportFactoryTypes,
+  SupportTypes,
 } from './interfaces/schema.types';
 import { HookHandler } from './interfaces/schema.types';
 import { cast, CAST_STRATEGY, CastOptions } from '../utils/cast-strategy';
 
 export class Schema {
-  static Types: SupportType = {
+  static FactoryTypes: SupportFactoryTypes = {
     String: stringTypeFactory,
     Boolean: booleanTypeFactory,
     Number: numberTypeFactory,
@@ -34,6 +44,17 @@ export class Schema {
     Array: arrayTypeFactory,
     Reference: referenceTypeFactory,
     Embed: embedTypeFactory,
+    Mixed: mixedTypeFactory,
+  };
+  static Types: SupportTypes = {
+    String: StringType.prototype,
+    Boolean: BooleanType.prototype,
+    Number: NumberType.prototype,
+    Date: DateType.prototype,
+    Array: ArrayType.prototype,
+    Reference: ReferenceType.prototype,
+    Embed: EmbedType.prototype,
+    Mixed: MixedType.prototype,
   };
   static validators: CustomValidations = {};
   statics: any = {};

--- a/src/schema/types/array-type.ts
+++ b/src/schema/types/array-type.ts
@@ -5,7 +5,14 @@ import { CoreTypeOptions, IOttomanType } from '../interfaces/schema.types';
 import { CAST_STRATEGY, checkCastStrategy, ensureArrayItemsType } from '../../utils/cast-strategy';
 
 /**
- * @inheritDoc
+ * Array type supports arrays of [SchemaTypes](/classes/schema.html#static-types) and arrays of subdocuments.
+ * @example
+ * ```typescript
+ * const postSchemaDef = new Schema({
+ *   postTags: [String],
+ *   comments: [{ type: commentSchema, ref: 'Comment' }],
+ * });
+ * ```
  */
 export class ArrayType extends CoreType {
   constructor(name: string, public itemType: IOttomanType, options?: CoreTypeOptions) {

--- a/src/schema/types/array-type.ts
+++ b/src/schema/types/array-type.ts
@@ -1,5 +1,5 @@
 import { CoreType } from './core-type';
-import { is } from '../../utils/is-type';
+import { is } from '../../utils';
 import { ValidationError } from '../errors';
 import { CoreTypeOptions, IOttomanType } from '../interfaces/schema.types';
 import { CAST_STRATEGY, checkCastStrategy, ensureArrayItemsType } from '../../utils/cast-strategy';
@@ -9,8 +9,10 @@ import { CAST_STRATEGY, checkCastStrategy, ensureArrayItemsType } from '../../ut
  */
 export class ArrayType extends CoreType {
   constructor(name: string, public itemType: IOttomanType, options?: CoreTypeOptions) {
-    super(name, Array.name, options);
+    super(name, ArrayType.sName, options);
   }
+
+  static sName = Array.name;
 
   cast(value: unknown, strategy = CAST_STRATEGY.DEFAULT_OR_DROP): unknown {
     if (is(value, Array)) {

--- a/src/schema/types/boolean-type.ts
+++ b/src/schema/types/boolean-type.ts
@@ -4,7 +4,14 @@ import { CoreTypeOptions } from '../interfaces/schema.types';
 import { CAST_STRATEGY, checkCastStrategy } from '../../utils/cast-strategy';
 
 /**
- * @inheritDoc
+ * `Boolean` are plain javascript booleans
+ * @example
+ * ```typescript
+ * const userSchema =  new Schema({
+ *   isActive: Boolean,
+ *   isSomething: Schema.Types.Boolean
+ * })
+ * ```
  */
 export class BooleanType extends CoreType {
   constructor(name: string, options?: CoreTypeOptions) {

--- a/src/schema/types/boolean-type.ts
+++ b/src/schema/types/boolean-type.ts
@@ -1,5 +1,5 @@
 import { CoreType } from './core-type';
-import { is } from '../../utils/is-type';
+import { is } from '../../utils';
 import { CoreTypeOptions } from '../interfaces/schema.types';
 import { CAST_STRATEGY, checkCastStrategy } from '../../utils/cast-strategy';
 
@@ -8,8 +8,9 @@ import { CAST_STRATEGY, checkCastStrategy } from '../../utils/cast-strategy';
  */
 export class BooleanType extends CoreType {
   constructor(name: string, options?: CoreTypeOptions) {
-    super(name, Boolean.name, options);
+    super(name, BooleanType.sName, options);
   }
+  static sName = Boolean.name;
 
   cast(value, strategy = CAST_STRATEGY.DEFAULT_OR_DROP) {
     const castedValue = Boolean(value);

--- a/src/schema/types/core-type.ts
+++ b/src/schema/types/core-type.ts
@@ -21,7 +21,12 @@ import { VALIDATION_STRATEGY } from '../../utils';
 export abstract class CoreType extends IOttomanType {
   protected constructor(name: string, typeName: string, public options?: CoreTypeOptions) {
     super(name, typeName);
+    this.name = name;
+    this.typeName = typeName;
   }
+
+  static sName;
+
   get required(): boolean | RequiredOption | RequiredFunction {
     return this.options?.required || false;
   }

--- a/src/schema/types/date-type.ts
+++ b/src/schema/types/date-type.ts
@@ -2,7 +2,7 @@ import { CoreType } from './core-type';
 import { DateFunction, DateOption, validateMaxDate, validateMinDate } from '../helpers';
 import { ValidationError } from '../errors';
 import { CoreTypeOptions } from '../interfaces/schema.types';
-import { is } from '../../utils/is-type';
+import { is } from '../../utils';
 import { CAST_STRATEGY, checkCastStrategy } from '../../utils/cast-strategy';
 import { isDateValid } from '../../utils/type-helpers';
 
@@ -16,10 +16,12 @@ interface DateTypeOptions {
  * @param options.min date value that will be accepted
  * @param options.max date value that will be accepted
  */
-class DateType extends CoreType {
+export class DateType extends CoreType {
   constructor(name: string, options?: DateTypeOptions & CoreTypeOptions) {
-    super(name, Date.name, options);
+    super(name, DateType.sName, options);
   }
+
+  static sName = Date.name;
 
   get min(): Date | DateOption | DateFunction | undefined {
     const _min = (this.options as DateTypeOptions).min;

--- a/src/schema/types/date-type.ts
+++ b/src/schema/types/date-type.ts
@@ -6,15 +6,24 @@ import { is } from '../../utils';
 import { CAST_STRATEGY, checkCastStrategy } from '../../utils/cast-strategy';
 import { isDateValid } from '../../utils/type-helpers';
 
+/**
+ * @field `min` date value that will be accepted
+ * @field `max` date value that will be accepted
+ * */
 interface DateTypeOptions {
   min?: Date | DateOption | DateFunction | string;
   max?: Date | DateOption | DateFunction | string;
 }
 
 /**
- * @inheritDoc
- * @param options.min date value that will be accepted
- * @param options.max date value that will be accepted
+ * `Date` are plain javascript date
+ * @example
+ * ```typescript
+ * const userSchema =  new Schema({
+ *   birthday: {type: Date, min: '1990-12-31', max: new Date()},
+ *   hired: Schema.Types.Date
+ * })
+ * ```
  */
 export class DateType extends CoreType {
   constructor(name: string, options?: DateTypeOptions & CoreTypeOptions) {

--- a/src/schema/types/embed-type.ts
+++ b/src/schema/types/embed-type.ts
@@ -13,7 +13,7 @@ import { cast, CAST_STRATEGY, checkCastStrategy } from '../../utils/cast-strateg
  * ```javascript
  * const userSchema = new Schema({
  *   name: String,
- *   email: String,
+ *   email: Schema.Types.String,
  *   createAt: Date,
  * });
  *

--- a/src/schema/types/embed-type.ts
+++ b/src/schema/types/embed-type.ts
@@ -1,7 +1,7 @@
 import { CoreType } from './core-type';
 import { Schema } from '../schema';
 import { isModel } from '../../utils/is-model';
-import { is } from '../../utils/is-type';
+import { is } from '../../utils';
 import { ValidationError } from '../errors';
 import { CoreTypeOptions } from '../interfaces/schema.types';
 import { cast, CAST_STRATEGY, checkCastStrategy } from '../../utils/cast-strategy';
@@ -38,10 +38,11 @@ import { cast, CAST_STRATEGY, checkCastStrategy } from '../../utils/cast-strateg
  * @tip
  * `EmbedType` will allow you to reuse easily your existing schemas into new one using composition.
  */
-class EmbedType extends CoreType {
+export class EmbedType extends CoreType {
   constructor(name: string, public schema: Schema, options?: CoreTypeOptions) {
-    super(name, 'Embed', options);
+    super(name, EmbedType.sName, options);
   }
+  static sName = 'Embed';
 
   cast(value: unknown, strategy = CAST_STRATEGY.DEFAULT_OR_DROP): unknown {
     if (!is(value, Object) && !isModel(value)) {

--- a/src/schema/types/index.ts
+++ b/src/schema/types/index.ts
@@ -1,8 +1,9 @@
 export { CoreType } from './core-type';
-export { stringTypeFactory } from './string-type';
-export { booleanTypeFactory } from './boolean-type';
-export { numberTypeFactory } from './number-type';
-export { dateTypeFactory } from './date-type';
+export { stringTypeFactory, StringType } from './string-type';
+export { booleanTypeFactory, BooleanType } from './boolean-type';
+export { numberTypeFactory, NumberType } from './number-type';
+export { dateTypeFactory, DateType } from './date-type';
 export { arrayTypeFactory, ArrayType } from './array-type';
-export { embedTypeFactory } from './embed-type';
+export { embedTypeFactory, EmbedType } from './embed-type';
 export { referenceTypeFactory, ReferenceType } from './reference-type';
+export { mixedTypeFactory, MixedType } from './mixed-type';

--- a/src/schema/types/mixed-type.ts
+++ b/src/schema/types/mixed-type.ts
@@ -1,0 +1,20 @@
+import { CoreType } from './core-type';
+import { CoreTypeOptions } from '../interfaces/schema.types';
+
+/**
+ * @inheritDoc
+ */
+export class MixedType extends CoreType {
+  constructor(name: string, options?: CoreTypeOptions) {
+    super(name, MixedType.sName, options);
+  }
+  static sName = 'Mixed';
+
+  cast(value: unknown, strategy) {
+    value = super.validate(value, strategy);
+    this.checkValidator(value);
+    return value;
+  }
+}
+
+export const mixedTypeFactory = (name: string, otps: CoreTypeOptions): MixedType => new MixedType(name, otps);

--- a/src/schema/types/mixed-type.ts
+++ b/src/schema/types/mixed-type.ts
@@ -2,7 +2,15 @@ import { CoreType } from './core-type';
 import { CoreTypeOptions } from '../interfaces/schema.types';
 
 /**
- * @inheritDoc
+ * `Mixed` type supports any `Object` types, you can change the value to anything else you like, it can be represented in the following ways:
+ * @example
+ * ```typescript
+ * const customSchema = new Schema({
+ *   empty: {},
+ *   obj: Object,
+ *   mixed: Schema.Types.Mixed,
+ * });
+ * ```
  */
 export class MixedType extends CoreType {
   constructor(name: string, options?: CoreTypeOptions) {

--- a/src/schema/types/number-type.ts
+++ b/src/schema/types/number-type.ts
@@ -2,7 +2,7 @@ import { CoreType } from './core-type';
 import { MinmaxOption, NumberFunction, validateMaxLimit, validateMinLimit } from '../helpers';
 import { ValidationError } from '../errors';
 import { CoreTypeOptions } from '../interfaces/schema.types.js';
-import { is } from '../../utils/is-type';
+import { is } from '../../utils';
 import { CAST_STRATEGY, checkCastStrategy } from '../../utils/cast-strategy';
 import { isNumber } from '../../utils/type-helpers';
 
@@ -17,10 +17,11 @@ interface NumberTypeOptions {
  * @param options.min numeric value that will be accepted
  * @param options.max numeric value that will be accepted
  */
-class NumberType extends CoreType {
+export class NumberType extends CoreType {
   constructor(name: string, options?: CoreTypeOptions & NumberTypeOptions) {
-    super(name, Number.name, options);
+    super(name, NumberType.sName, options);
   }
+  static sName = Number.name;
 
   get max(): number | NumberFunction | MinmaxOption | undefined {
     const _options = this.options as NumberTypeOptions;

--- a/src/schema/types/number-type.ts
+++ b/src/schema/types/number-type.ts
@@ -6,16 +6,25 @@ import { is } from '../../utils';
 import { CAST_STRATEGY, checkCastStrategy } from '../../utils/cast-strategy';
 import { isNumber } from '../../utils/type-helpers';
 
+/**
+ * @field `intVal` flag that will allow only integer values
+ * @field `min` numeric value that will be accepted
+ * @field `max` numeric value that will be accepted
+ * */
 interface NumberTypeOptions {
   intVal?: boolean;
   min?: number | NumberFunction | MinmaxOption;
   max?: number | NumberFunction | MinmaxOption;
 }
 /**
- * @inheritDoc
- * @param options.intVal flag that will allow only integer values
- * @param options.min numeric value that will be accepted
- * @param options.max numeric value that will be accepted
+ * `Number` are plain javascript number
+ *
+ * @example
+ * ```typescript
+ * const userSchema =  new Schema({
+ *   age: Number,
+ * })
+ * ```
  */
 export class NumberType extends CoreType {
   constructor(name: string, options?: CoreTypeOptions & NumberTypeOptions) {

--- a/src/schema/types/reference-type.ts
+++ b/src/schema/types/reference-type.ts
@@ -11,7 +11,19 @@ interface ReferenceOptions {
 }
 
 /**
- * @inheritDoc
+ * The `Reference` type creates a relationship between two schemas.
+ *
+ * @example
+ * ```typescript
+ * const Cat = model('Cat', {name: String});
+ * const schema = new Schema({
+ *     type: String,
+ *     isActive: Boolean,
+ *     name: String,
+ *     cats: [{ type: CatSchema, ref: 'Cat' }],
+ *   });
+ * const User = model('User', schema);
+ * ```
  */
 export class ReferenceType extends CoreType {
   constructor(name: string, public schema: Schema, public refModel: string, options?: CoreTypeOptions) {

--- a/src/schema/types/reference-type.ts
+++ b/src/schema/types/reference-type.ts
@@ -1,6 +1,6 @@
 import { CoreType } from './core-type';
 import { Schema } from '../schema';
-import { is } from '../../utils/is-type';
+import { is } from '../../utils';
 import { isModel } from '../../utils/is-model';
 import { ValidationError } from '../errors';
 import { CoreTypeOptions } from '../interfaces/schema.types';
@@ -15,8 +15,9 @@ interface ReferenceOptions {
  */
 export class ReferenceType extends CoreType {
   constructor(name: string, public schema: Schema, public refModel: string, options?: CoreTypeOptions) {
-    super(name, 'Reference', options);
+    super(name, ReferenceType.sName, options);
   }
+  static sName = 'Reference';
 
   cast(value) {
     return value;

--- a/src/schema/types/string-type.ts
+++ b/src/schema/types/string-type.ts
@@ -1,6 +1,6 @@
 import { CoreType } from './core-type';
 import { generateUUID } from '../../utils/generate-uuid';
-import { is } from '../../utils/is-type';
+import { is } from '../../utils';
 import { BuildSchemaError, ValidationError } from '../errors';
 import { AutoFunction, CoreTypeOptions } from '../interfaces/schema.types';
 import { CAST_STRATEGY, checkCastStrategy } from '../../utils/cast-strategy';
@@ -19,9 +19,11 @@ export interface StringTypeOptions {
  */
 export class StringType extends CoreType {
   constructor(name: string, options?: CoreTypeOptions & StringTypeOptions) {
-    super(name, String.name, options);
+    super(name, StringType.sName, options);
     this._checkIntegrity();
   }
+
+  static sName = String.name;
 
   get enumValues(): unknown {
     const _options = this.options as StringTypeOptions;

--- a/src/schema/types/string-type.ts
+++ b/src/schema/types/string-type.ts
@@ -7,15 +7,28 @@ import { CAST_STRATEGY, checkCastStrategy } from '../../utils/cast-strategy';
 
 type FunctionsString = () => string[];
 
+/**
+ * Schema String Type Options
+ *
+ * @field `enum` defines a list of allowed values.
+ * @field `auto` that will generate the initial value of the field. It allows the value 'uuid' or a function. It cannot be used combined with default.
+ * */
 export interface StringTypeOptions {
   enum?: string[] | FunctionsString;
   auto?: string;
 }
 
 /**
- * @inheritDoc
- * @param options.enum defines a list of allowed values.
- * @param options.auto that will generate the initial value of the field. It allows the value 'uuid' or a function. It cannot be used combined with default.
+ * `String` are plain javascript string
+ *
+ * @example
+ * ```typescript
+ * const userSchema =  new Schema({
+ *   name: { type:String, auto: 'uuid' },
+ *   gender: { type: String, enum: ['M', 'F'] }
+ *   lastname: Schema.Types.String
+ * })
+ * ```
  */
 export class StringType extends CoreType {
   constructor(name: string, options?: CoreTypeOptions & StringTypeOptions) {

--- a/src/utils/index.ts
+++ b/src/utils/index.ts
@@ -1,2 +1,3 @@
 export { isDocumentNotFoundError } from './is-not-found';
 export { VALIDATION_STRATEGY } from './validation.strategy';
+export { is, isSchemaTypeSupported, isSchemaFactoryType } from './is-type';

--- a/src/utils/is-type.ts
+++ b/src/utils/is-type.ts
@@ -8,10 +8,19 @@ import { Schema } from '../schema';
 export const is = (val, type): boolean =>
   ![, null].includes(val) && (val.name === type.name || val.constructor.name === type.name);
 
+/**
+ * Checking if a value is a type supported by Ottoman
+ * @param val
+ */
 export const isSchemaTypeSupported = (val): boolean => {
   return val.constructor['sName'] in Schema.Types;
 };
 
+/**
+ * Checking if a value is a factory supported by Ottoman
+ * @param value
+ * @param factory List of Schema Factories
+ */
 export const isSchemaFactoryType = (value, factory): boolean => {
   return value.name in factory;
 };

--- a/src/utils/is-type.ts
+++ b/src/utils/is-type.ts
@@ -1,7 +1,17 @@
+import { Schema } from '../schema';
+
 /**
  * Checking if a value is a specific type or constructor
  * @param val
  * @param type
  */
 export const is = (val, type): boolean =>
-  ![, null].includes(val) && (val.name === type || val.constructor.name === type || val.constructor === type);
+  ![, null].includes(val) && (val.name === type.name || val.constructor.name === type.name);
+
+export const isSchemaTypeSupported = (val): boolean => {
+  return val.constructor['sName'] in Schema.Types;
+};
+
+export const isSchemaFactoryType = (value, factory): boolean => {
+  return value.name in factory;
+};

--- a/vuepress/guides/schema.md
+++ b/vuepress/guides/schema.md
@@ -6,51 +6,56 @@ Schema maps to a Couchbase collection and defines the shape of the documents wit
 
 ## Defining your schema
 
-Everything in Ottoman starts with a Schema. 
+Everything in Ottoman starts with a Schema.
 
 ```javascript
 const blogSchema = new Schema({
-  title:  { type: String, required: true },
-  author: String,  // String is shorthand for {type: String}
-  body:   String,
+  title: { type: String, required: true },
+  author: String, // String is shorthand for {type: String},
+  authorNative: Schema.Types.String,
+  body: String,
   comments: [{ body: String, date: Date }],
   date: { type: Date, default: Date.now },
   hidden: Boolean,
-  status: { type: String, enum: ["Close", "Open", "Review"] },
+  status: { type: String, enum: ['Close', 'Open', 'Review'] },
   meta: {
     votes: { type: Number, min: 0, max: 5 },
-    favs:  Number
-  }
+    favs: Number,
+  },
+  mixedObject: Object,
+  mixedNative: Schema.Types.Mixed,
 });
 ```
+
 For more information about options, please [review the types ](/guides/schema.html#allowed-schematypes-are)
 
 Each key in our code blogSchema defines a property in our documents which will be cast to its associated SchemaType. For example, we've defined a property title which will be casted to the String SchemaType and property date which will be casted to a Date SchemaType.
 
 Please note above that if a property only requires a type, it can be specified using a shorthand notation (contrast the title property above with the date property).
 
-Keys may also be assigned to nested objects containing further key/type definitions like the meta property above. 
-This will happen whenever a key's value is a POJO that lacks a bona-fide type property. 
+Keys may also be assigned to nested objects containing further key/type definitions like the meta property above.
+This will happen whenever a key's value is a POJO that lacks a bona-fide type property.
 In these cases, only the leaves in a tree are given actual paths in the schema (like meta.votes and meta.favs above), and the branches do not have actual paths.
 A side-effect of this is that meta above cannot have its own validation. If validation is needed up the tree, a path needs to be created up the tree.
 
-
 ## Allowed SchemaTypes are:
-* [String](/classes/stringtype)
-* [Number](/classes/numbertype)
-* [Boolean](/classes/booleantype)
-* [Date](/classes/datetype)
-* [Array](/classes/arraytype)
-* [Embed](/classes/embedtype)
-* [Reference](/classes/referencetype)
 
+- [String](/classes/stringtype)
+- [Number](/classes/numbertype)
+- [Boolean](/classes/booleantype)
+- [Date](/classes/datetype)
+- [Array](/classes/arraytype)
+- [Embed](/classes/embedtype)
+- [Reference](/classes/referencetype)
+- [Mixed](/classes/mixedtype)
 
 Schemas not only define the structure of your document and casting of properties,
-they also define document instance methods, static Model methods, 
+they also define document instance methods, static Model methods,
 compound indexes, plugins and document lifecycle hooks.
 
 ## Creating a model
-To use our schema definition, we need to convert our blogSchema into a Model we can work with. 
+
+To use our schema definition, we need to convert our blogSchema into a Model we can work with.
 To do so, we pass it into `model(modelName, schema)`:
 
 ```javascript
@@ -60,40 +65,41 @@ const Blog = model('Blog', blogSchema);
 
 ## Indexes
 
-You can specify several indexes on a model.  There are different kinds of indexes, each with its own benefits and restrictions.
+You can specify several indexes on a model. There are different kinds of indexes, each with its own benefits and restrictions.
 
 To specify indexes on a [Schema](/guides/schema), use the index key on the schema:
+
 ```javascript
-import {Schema} from 'ottoman';
+import { Schema } from 'ottoman';
 
 const schema = new Schema({
   email: String,
   name: {
     first: String,
     last: String,
-    full: String
-  }
+    full: String,
+  },
 });
 
 schema.index.findByEmail = {
   by: 'email',
-  type: 'refdoc'
+  type: 'refdoc',
 };
 
 schema.index.findByFirstName = {
   by: 'name.first',
-  type: 'view'
+  type: 'view',
 };
 
 schema.index.findByLastName = {
   by: 'name.last',
-  type: 'n1ql'
+  type: 'n1ql',
 };
 ```
 
 To ensure that server is working, you must call the `start` method.
 This method will internally generate a list of indexes and scopes, collections (if you have the developer preview active)
-which will be used with the most optimal configuration for them and will build the structures that might be missing on the server. 
+which will be used with the most optimal configuration for them and will build the structures that might be missing on the server.
 This method must be called after all models are defined, and it is a good idea to call this only when needed rather than any time your server is started.
 
 ```javascript
@@ -105,43 +111,46 @@ const app = express();
 
 app.use('/users', UserRoutes);
 const useCollections = false; // set this to true to create scopes/collections.
-start({ useCollections })
-  .then(() => {
-    console.log('Ottoman is ready!');
-    app.listen(5000);
-  })
+start({ useCollections }).then(() => {
+  console.log('Ottoman is ready!');
+  app.listen(5000);
+});
 ```
 
 ## Index Types
 
-Below are some quick notes on the types of indexes available, and their pros and cons.  For a more in-depth discussion, consider
+Below are some quick notes on the types of indexes available, and their pros and cons. For a more in-depth discussion, consider
 reading [Couchbasics: How Functional and Performance Needs Determine Data Access in Couchbase](https://blog.couchbase.com/determine-data-access-in-couchbase/)
 
 ### `refdoc`
-These indexes are the most performant, but the least flexible.  They allow only a single document to occupy any particular value and do direct key-value lookups using a referential document to identify a matching document in Couchbase.
 
-In short, if you need to look up a document by a single value of a single attribute quickly (e.g. key lookups), this is the way to go.  But you cannot combine multiple refdoc indexes to speed up finding
+These indexes are the most performant, but the least flexible. They allow only a single document to occupy any particular value and do direct key-value lookups using a referential document to identify a matching document in Couchbase.
+
+In short, if you need to look up a document by a single value of a single attribute quickly (e.g. key lookups), this is the way to go. But you cannot combine multiple refdoc indexes to speed up finding
 something like "all customers with first name 'John' last name 'Smith'".
 
 ### `view`
-These indexes are the default and use map-reduce views.  This type of index is always available once `ensureIndexes` is called and will work with any Couchbase Server version.
+
+These indexes are the default and use map-reduce views. This type of index is always available once `ensureIndexes` is called and will work with any Couchbase Server version.
 
 Because views use map-reduce, certain types of queries can be faster as the query can be parallelized over all nodes in the cluster, with each node
-returning only partial results.  One of the cons of views is that they are eventually consistent by default, and incur a performance
+returning only partial results. One of the cons of views is that they are eventually consistent by default, and incur a performance
 penalty if you want consistency in the result.
 
 ### `n1ql`
-These indexes uses the new SQL-like query language available from Couchbase Server 4.0.0.  These indexes are more performant than views in many cases and are significantly more flexible, allowing even un-indexed searches.
 
-N1QL indexes in Ottoman use [Couchbase GSIs](http://developer.couchbase.com/documentation/server/current/indexes/gsi-for-n1ql.html).  If you need flexibility of queries and
+These indexes uses the new SQL-like query language available from Couchbase Server 4.0.0. These indexes are more performant than views in many cases and are significantly more flexible, allowing even un-indexed searches.
+
+N1QL indexes in Ottoman use [Couchbase GSIs](http://developer.couchbase.com/documentation/server/current/indexes/gsi-for-n1ql.html). If you need flexibility of queries and
 speed, this is the way to go.
 
 ## Instance methods
-Instances of Models are [documents](/guides/document.md). Documents have many of their own built-in instance methods. 
+
+Instances of Models are [documents](/guides/document.md). Documents have many of their own built-in instance methods.
 We may also define our own custom document instance methods.
 
 ```javascript
-import {connect, Schema} from 'ottoman';
+import { connect, Schema } from 'ottoman';
 // connecting
 const connection = connect('couchbase://localhost/travel-sample@admin:password');
 
@@ -149,8 +158,8 @@ const connection = connect('couchbase://localhost/travel-sample@admin:password')
 const animalSchema = new Schema({ name: String, type: String });
 
 // assign a function to the "methods" object of our animalSchema
-animalSchema.methods.findSimilarTypes = function() {
-return connection.getModel('Animal').find({ type: this.type });
+animalSchema.methods.findSimilarTypes = function () {
+  return connection.getModel('Animal').find({ type: this.type });
 };
 ```
 
@@ -161,12 +170,12 @@ const Animal = model('Animal', animalSchema);
 const dog = new Animal({ type: 'dog' });
 
 const dogs = await dog.findSimilarTypes();
-console.log(dogs); 
+console.log(dogs);
 ```
 
-* Overwriting a default Ottoman document method may lead to unpredictable results.
-* The example above uses the Schema.methods object directly to save an instance method.
-* Do not declare methods using ES6 arrow functions (=>). Arrow functions explicitly prevent binding this, so your method will not have access to the document and the above examples will not work.
+- Overwriting a default Ottoman document method may lead to unpredictable results.
+- The example above uses the Schema.methods object directly to save an instance method.
+- Do not declare methods using ES6 arrow functions (=>). Arrow functions explicitly prevent binding this, so your method will not have access to the document and the above examples will not work.
 
 ## Statics
 
@@ -177,7 +186,7 @@ Call the Schema#static() function
 
 ```javascript
 // Assign a function to the "statics" object of our animalSchema
-animalSchema.statics.findByName = function(name) {
+animalSchema.statics.findByName = function (name) {
   return this.find({ name: name });
 };
 
@@ -190,7 +199,7 @@ so the above examples will not work because of the value of this.
 
 ## Hooks
 
-Hooks are functions which are passed control during execution of asynchronous functions. 
+Hooks are functions which are passed control during execution of asynchronous functions.
 Hooks are specified at the schema level and are useful for writing plugins.
 
 ### The available hooks are:
@@ -214,14 +223,14 @@ schema.pre('save', function(document) {
 ```
 
 You can use a function that returns a promise. In particular, you can use async/await.
+
 ```javascript
-schema.pre('save', function() {
-  return doStuff().
-    then(() => doMoreStuff());
+schema.pre('save', function () {
+  return doStuff().then(() => doMoreStuff());
 });
 
 // Or, in Node.js >= 7.6.0:
-schema.pre('save', async function() {
+schema.pre('save', async function () {
   await doStuff();
   await doMoreStuff();
 });
@@ -241,19 +250,19 @@ Hooks are useful for atomizing model logic. Here we list some ideas:
 If any pre hook errors out, Ottoman will not execute subsequent hooks or the hooked function.
 
 ```javascript
-schema.pre('save', function() {
+schema.pre('save', function () {
   // You can also return a promise that rejects
   return new Promise((resolve, reject) => {
     reject(new Error('something went wrong'));
   });
 });
 
-schema.pre('save', function() {
+schema.pre('save', function () {
   // You can also throw a synchronous error
   throw new Error('something went wrong');
 });
 
-schema.pre('save', async function() {
+schema.pre('save', async function () {
   await Promise.resolve();
   // You can also throw an error in an `async` function
   throw new Error('something went wrong');
@@ -274,13 +283,13 @@ try {
 `post` middleware are executed after the hooked method and all of its pre hooks have completed.
 
 ```javascript
-schema.post('validate', function(doc) {
+schema.post('validate', function (doc) {
   console.log('%s has been validated (but not saved yet)', doc.id);
 });
-schema.post('save', function(doc) {
+schema.post('save', function (doc) {
   console.log('%s has been saved', doc.id);
 });
-schema.post('remove', function(doc) {
+schema.post('remove', function (doc) {
   console.log('%s has been removed', doc.id);
 });
 ```
@@ -309,16 +318,16 @@ This means that all `pre('validate')` and `post('validate')` hooks get called be
 The `updateById()` function have the same behavior.
 
 ```javascript
-schema.pre('validate', function() {
+schema.pre('validate', function () {
   console.log('this gets printed first');
 });
-schema.post('validate', function() {
+schema.post('validate', function () {
   console.log('this gets printed second');
 });
-schema.pre('save', function() {
+schema.pre('save', function () {
   console.log('this gets printed third');
 });
-schema.post('save', function() {
+schema.post('save', function () {
   console.log('this gets printed fourth');
 });
 ```
@@ -355,6 +364,7 @@ await user.save();
 ```
 
 ### Global Plugins
+
 Want to register a plugin for all schemas? The Ottoman `registerGlobalPlugin` function registers a plugin for every schema. For example:
 
 ```javascript
@@ -382,7 +392,7 @@ await user.save();
 
 ## Strict Mode
 
-The strict option, (enabled by default), 
+The strict option, (enabled by default),
 ensures that values passed to our model constructor that were not specified in our schema do not get saved to the db.
 
 ```javascript
@@ -401,8 +411,8 @@ This value can be overridden at the model instance level by passing as second ar
 
 ```javascript
 const User = model('User', userSchema);
-const user = new User(doc, {strict: true});  // enables strict mode
-const user = new User(doc, {strict: false}); // disables strict mode
+const user = new User(doc, { strict: true }); // enables strict mode
+const user = new User(doc, { strict: false }); // disables strict mode
 ```
 
 ## Schema Helpful Methods
@@ -410,6 +420,7 @@ const user = new User(doc, {strict: false}); // disables strict mode
 Each `Schema` instance have two helpful methods `cast` and `validate`.
 
 ### Cast method
+
 The `cast` method get a Javascript Object as first parameter and enforce schema types for each field in the schema definition.
 
 ```javascript
@@ -444,6 +455,7 @@ interface CastOptions {
   strategy?: CAST_STRATEGY;
 }
 ```
+
 - `strict` will remove field not defined in the schema. The default value is set to true.
 - `skip` will be a string array with values of the key you may want to prevent to cast. The default value is empty [].
 - `strategy` when cast action fail, defined strategy is apply. The default strategy is set to `defaultOrDrop`
@@ -490,11 +502,13 @@ const result = schema.validate({
 #### Validate method options
 
 `validate` method have 1 options:
+
 ```javascript
 {
-  strict: boolean // strict set to true, will remove field not defined in the schema.
+  strict: boolean; // strict set to true, will remove field not defined in the schema.
 }
 ```
+
 By default, it will get the `strict` option value set via the Schema constructor.
 
 ## Next Up


### PR DESCRIPTION
Add support for Mixed Type.
`Mixed` type supports any `Object` types, you can change the value to anything else you like, it can be represented in the following ways:
```ts
const UserSchema = new Schema({
  inline: Schema.Types.Mixed,
  type: { type: Schema.Types.Mixed, required: true },
  any: Object,
  other: {},
});
```
