### PR TITLE
fix: update updateById method to pass Throw Strategy by default

### DIFF
--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -1,0 +1,24 @@
+{
+  // Use IntelliSense to learn about possible attributes.
+  // Hover to view descriptions of existing attributes.
+  // For more information, visit: https://go.microsoft.com/fwlink/?linkid=830387
+  "version": "0.2.0",
+  "configurations": [
+    {
+      "name": "Attach",
+      "port": 9229,
+      "request": "attach",
+      "skipFiles": ["<node_internals>/**"],
+      "type": "pwa-node",
+      "env": { "OTTOMAN_LEGACY_TEST": 1 }
+    },
+
+    {
+      "type": "pwa-chrome",
+      "request": "launch",
+      "name": "Launch Chrome against localhost",
+      "url": "http://localhost:8080",
+      "webRoot": "${workspaceFolder}"
+    }
+  ]
+}

--- a/__test__/handler-update-many.spec.ts
+++ b/__test__/handler-update-many.spec.ts
@@ -83,4 +83,26 @@ describe('Test Document Update Many', () => {
       await cleanUp();
     }
   });
+
+  test('Test Update Many Model Strict and Model Strategy', async () => {
+    const CatSchema = new Schema({
+      name: String,
+      age: Number,
+    });
+    const Cat = model('Cat', CatSchema);
+    await startInTest(getDefaultInstance());
+
+    await Cat.create({ name: 'Cat0', age: 27 });
+    await Cat.create({ name: 'Cat1', age: 28 });
+    await delay(500);
+
+    const response = await Cat.updateMany({ name: { $like: '%Cat%' } }, { age: 'Cats' });
+
+    expect(response.status).toBe('FAILED');
+    expect(response.message.errors[0].exception).toBe('ValidationError');
+
+    await delay(500);
+    const cleanUp = async () => await Cat.removeMany({ _type: 'Cat' });
+    await cleanUp();
+  });
 });

--- a/src/model/create-model.ts
+++ b/src/model/create-model.ts
@@ -196,7 +196,7 @@ export const _buildModel = (metadata: ModelMetadata) => {
           ...data,
           ...{ [modelKey]: value[modelKey] },
         };
-        const instance = new _Model({ ...updated });
+        const instance = new _Model({ ...updated }, { strategy: CAST_STRATEGY.THROW });
         return instance.save();
       }
       throw new (couchbase as any).DocumentNotFoundError();


### PR DESCRIPTION
Fix: https://github.com/bwgjoseph/mongoose-vs-ottoman/issues/15
Set Strategy to THROW in updateById method