### PR TITLE
test: add test case for ANY X SATISFIES where clause

### DIFF
--- a/__test__/query-builder.spec.ts
+++ b/__test__/query-builder.spec.ts
@@ -117,7 +117,7 @@ describe('Test Query Builder functions', () => {
     const where: LogicalWhereExpr = {
       $any: {
         $expr: [{ $dummyIn: { search_expr: 'search', target_expr: 'address' } }],
-        $satisfied: { address: '10' },
+        $satisfies: { address: '10' },
       },
     };
     try {
@@ -135,7 +135,7 @@ describe('Test Query Builder functions', () => {
     const where: LogicalWhereExpr = {
       $any: {
         $expr: [{ $dummyIn: { search_expr: 'search', target_expr: 'address' } }],
-        $satisfied: { address: '10' },
+        $satisfies: { address: '10' },
       },
     };
     try {
@@ -147,5 +147,30 @@ describe('Test Query Builder functions', () => {
         'The Collection Operator needs to have the following clauses declared (IN | WITHIN) and SATISFIES.',
       );
     }
+  });
+
+  test('buildWhereClauseExpr -> ANY X SATISFIES Clause ', async () => {
+    const filter = {
+      $and: [
+        {
+          $any: {
+            $expr: [{ $in: { search_expr: 'visibility', target_expr: 'network_visibility' } }],
+            $satisfies: { $in: { search_expr: 'visibility', target_expr: [2] } },
+          },
+        },
+        {
+          $any: {
+            $expr: [{ $in: { search_expr: 'visibility', target_expr: 'network_visibility' } }],
+            $satisfies: { visibility: [2] },
+          },
+        },
+      ],
+    };
+
+    const result = buildWhereClauseExpr('', filter);
+
+    expect(result).toBe(
+      '(ANY visibility IN network_visibility SATISFIES visibility IN [2] END AND ANY visibility IN network_visibility SATISFIES visibility=[2] END)',
+    );
   });
 });

--- a/__test__/query-select.spec.ts
+++ b/__test__/query-select.spec.ts
@@ -256,7 +256,7 @@ describe('Test Query Builder SELECT clause', () => {
     const where: LogicalWhereExpr = {
       $any: {
         $expr: [{ $in: { search_expr: 'search', target_expr: 'address' } }],
-        $satisfied: { address: '10' },
+        $satisfies: { address: '10' },
       },
     };
     const query = new Query({}, bucketName).select().where(where).limit(10).build();

--- a/src/model/index/n1ql/build-index-query.ts
+++ b/src/model/index/n1ql/build-index-query.ts
@@ -24,7 +24,7 @@ export const buildIndexQuery = (Model, fields, indexFnName, indexOptions = {}) =
         const [target, targetField] = field.split('[*].');
         filter['$any'] = {
           $expr: [{ $in: { search_expr: 'x', target_expr: target } }],
-          $satisfied: { [`x.${targetField}`]: values[i] },
+          $satisfies: { [`x.${targetField}`]: values[i] },
         };
       } else {
         filter[field] = values[i];

--- a/src/query/helpers/builders.ts
+++ b/src/query/helpers/builders.ts
@@ -267,7 +267,7 @@ export const buildWhereExpr = (expr: LogicalWhereExpr | undefined, clause?: stri
 export const verifyWhereObjectKey = (clause: LogicalWhereExpr) => {
   let exist = false;
   for (const key in clause) {
-    if (['$and', '$or', '$not', '$any', '$$every', '$in', '$within'].includes(key)) {
+    if (['$and', '$or', '$not', '$any', '$every', '$in', '$within'].includes(key)) {
       exist = true;
       break;
     }
@@ -322,7 +322,7 @@ const _buildFieldClauseExpr = (field: Record<string, string | number | boolean |
   try {
     const expr = Object.keys(field).map((value: string) => {
       if (typeof field[value] === 'object' && !Array.isArray(field[value])) {
-        return `${_buildComparisionClauseExpr(value, field[value] as ComparisonWhereExpr)}`;
+        return `${_buildComparisonClauseExpr(value, field[value] as ComparisonWhereExpr)}`;
       }
       if (!value.includes('$')) {
         if (typeof field[value] === 'string') {
@@ -346,7 +346,7 @@ const _buildFieldClauseExpr = (field: Record<string, string | number | boolean |
 /**
  * @ignore
  * */
-const _buildComparisionClauseExpr = (fieldName: string, comparison: ComparisonWhereExpr) => {
+const _buildComparisonClauseExpr = (fieldName: string, comparison: ComparisonWhereExpr) => {
   try {
     const expr = Object.keys(comparison)
       .map((value: string) => {
@@ -419,7 +419,7 @@ const _buildCollectionInWithIn = (collection: CollectionInWithinOperatorType) =>
 const _buildWhereCollectionExpr = (op: CollectionSelectOperator, expr: CollectionExpressionType) => {
   return `${CollectionSelectOperatorDict[op]} ${expr.$expr.map((value) => _buildCollectionInWithIn(value)).join(',')} ${
     CollectionSatisfiesOperatorDict['$satisfies']
-  } ${buildWhereClauseExpr('', expr.$satisfied)} END`;
+  } ${buildWhereClauseExpr('', expr.$satisfies)} END`;
 };
 
 // end where expression functions

--- a/src/query/interface/query.types.ts
+++ b/src/query/interface/query.types.ts
@@ -96,14 +96,14 @@ export type CollectionInWithinOperatorType = {
  * */
 export interface CollectionExpressionType {
   $expr: CollectionInWithinOperatorType[];
-  $satisfied: FieldWhereExpr;
+  $satisfies: FieldWhereExpr;
 }
 /**
  * Structure of the collection in within operator
  *
  * @example
  * ```
- * {$any: {$expr: [{$in:{search_expr: 'search', target_expr: 'address', $not: true} }], $satisfied:{address: '10'}}}
+ * {$any: {$expr: [{$in:{search_expr: 'search', target_expr: 'address', $not: true} }], $satisfies:{address: '10'}}}
  * ```
  * */
 export type CollectionSelectOperatorType = {

--- a/vuepress/guides/query-builder.md
+++ b/vuepress/guides/query-builder.md
@@ -34,7 +34,7 @@ const params = {
     ],
     $any: {
       $expr: [{ $in: { search_expr: 'search', target_expr: 'address' } }],
-      $satisfied: { address: '10' },
+      $satisfies: { address: '10' },
     },
     $in: { search_expr: 'search', target_expr: ['address'] },
   },


### PR DESCRIPTION
To test the clause try this:
```
const filter = {
  $any: {
    $expr: [{ $in: { search_expr: 'visibility', target_expr: 'network_visibility' } }],
    $satisfied: { $in: { search_expr: 'visibility', target_expr: [2] } },
  },
};

const result  = model.find(filter);
```

The resulting query must be like:
```sql
SELECT `travel-sample`.* FROM `travel-sample` WHERE ANY visibility IN network_visibility SATISFIES visibility IN [2] END  AND _type="Application"
```
close #426 