### PR TITLE
feat(query): add $ignoreCase property to the query builder where operators

### DIFF
--- a/__test__/ignore-case.spec.ts
+++ b/__test__/ignore-case.spec.ts
@@ -1,0 +1,75 @@
+import { buildWhereClauseExpr, getDefaultInstance, LogicalWhereExpr, model } from '../src';
+import { delay, startInTest } from './testData';
+
+describe('Options to ignore case', () => {
+  const doc = {
+    type: 'airline',
+    isActive: false,
+    name: 'Ottoman Access Find Lean',
+  };
+  const schema = {
+    type: String,
+    isActive: Boolean,
+    name: String,
+  };
+  test(`Ignore case with buildWhereClause`, () => {
+    const where01: LogicalWhereExpr = {
+      name: 'John',
+    } as LogicalWhereExpr;
+    const where02: LogicalWhereExpr = {
+      name: { $eq: 'John' },
+    } as LogicalWhereExpr;
+    expect(buildWhereClauseExpr('', where01)).toStrictEqual(buildWhereClauseExpr('', where02));
+
+    const where1: LogicalWhereExpr = {
+      name: { $eq: 'John', $ignoreCase: true },
+    } as LogicalWhereExpr;
+    expect(buildWhereClauseExpr('', where1)).toStrictEqual('(LOWER(name) = LOWER("John"))');
+
+    const where2: LogicalWhereExpr = {
+      name: { $like: 'John', $ignoreCase: true },
+    } as LogicalWhereExpr;
+    expect(buildWhereClauseExpr('', where2)).toStrictEqual('(LOWER(name) LIKE LOWER("John"))');
+
+    const where3: LogicalWhereExpr = {
+      name: { $like: 'John', $eq: 'John', $ignoreCase: true },
+    } as LogicalWhereExpr;
+    expect(buildWhereClauseExpr('', where3)).toStrictEqual(
+      '(LOWER(name) LIKE LOWER("John") AND LOWER(name) = LOWER("John"))',
+    );
+  });
+
+  test('Test ignoreCase false value', async () => {
+    const where = { name: { $eq: 'oTToman aCCess', $ignoreCase: false } };
+    const result = buildWhereClauseExpr('', where);
+    expect(result).toBe('(name="oTToman aCCess")');
+  });
+
+  test('Test ignoreCase boolean exception', async () => {
+    const where = { name: { $eq: 'oTToman aCCess', $ignoreCase: 'true' } };
+    const test = () => buildWhereClauseExpr('', where);
+    expect(test).toThrow(new TypeError('The data type of $ignoreCase must be Boolean'));
+  });
+
+  test('Using find $eq', async () => {
+    const UserModel = model('User', schema);
+    await startInTest(getDefaultInstance());
+    const { id } = await UserModel.create(doc);
+    await delay(500);
+    const { rows: documents } = await UserModel.find({ name: { $eq: 'oTToman aCCess find lean', $ignoreCase: true } });
+    await UserModel.removeById(id);
+    expect(documents[0].name).toStrictEqual('Ottoman Access Find Lean');
+  });
+
+  test('Using find $like', async () => {
+    const UserModel = model('User', schema);
+    await startInTest(getDefaultInstance());
+    const { id } = await UserModel.create(doc);
+    await delay(500);
+    const { rows: documents } = await UserModel.find({
+      name: { $like: 'oTToman aCCess find lean', $ignoreCase: true },
+    });
+    await UserModel.removeById(id);
+    expect(documents[0].name).toStrictEqual('Ottoman Access Find Lean');
+  });
+});

--- a/__test__/schema-inmutable.spec.ts
+++ b/__test__/schema-inmutable.spec.ts
@@ -40,7 +40,7 @@ describe('Test Schema Immutable', () => {
     const Card = model('Card', CardSchemaBase);
     await startInTest(getDefaultInstance());
     await Card.create(cardInfo);
-    await delay(500);
+    await delay(1500);
     const result = await Card.findOne({ cardNumber: '5678 5678 5678 5678' });
     result.cardNumber = '80';
     await Card.removeById(result.id);

--- a/src/model/model.ts
+++ b/src/model/model.ts
@@ -54,6 +54,7 @@ export abstract class Model<T = any> extends Document<T> {
    * $and: [
    *   { price2: { $gt: 1.99, $isNotNull: true } },
    *   { $or: [{ price3: { $gt: 1.99, $isNotNull: true } }, { id: '20' }] },
+   *   {name: {$eq: 'John', $ignoreCase: true}}
    *  ],
    * };
    * User.find(filter)

--- a/src/query/interface/query.types.ts
+++ b/src/query/interface/query.types.ts
@@ -72,6 +72,11 @@ export type CollectionInWithinOperator = '$in' | '$within';
  * */
 export type CollectionSatisfiesOperator = '$satisfies';
 
+/**
+ * List of String Modifiers.
+ * */
+export type StringModifiers = '$ignoreCase';
+
 export interface CollectionInWithinOperatorValue {
   search_expr: unknown;
   target_expr: unknown;
@@ -136,7 +141,9 @@ export type ComparisonWhereExpr = {
  * ```
  *
  * */
-export type FieldWhereExpr = Record<string, string | number | boolean | ComparisonWhereExpr> | LogicalWhereExpr;
+export type FieldWhereExpr =
+  | Record<string, string | number | boolean | ComparisonWhereExpr | StringModifiers>
+  | LogicalWhereExpr;
 
 /**
  * Structure of Logical WHERE expression

--- a/src/query/query.ts
+++ b/src/query/query.ts
@@ -232,7 +232,7 @@ export class Query extends BaseQuery {
    *
    * @example
    * ```ts
-   *   const expr_where = {$or: [{ address: { $like: '%57-59%' } }, { free_breakfast: true }]};
+   *   const expr_where = {$or: [{ address: { $like: '%57-59%' } }, { free_breakfast: true }, {name: { $eq: 'John', $ignoreCase: true }}]};
    *   const query = new Query({}, 'travel-sample');
    *   const result = query.select([{$field: 'address'}]).where(expr_where).build()
    *   console.log(result)

--- a/vuepress/guides/model.md
+++ b/vuepress/guides/model.md
@@ -138,6 +138,10 @@ User.find({ name: 'Jane' });
 
 User.find({ name: 'Jane' }, { limit: 10 });
 // will return a list of all users with the name "Jane" and limited to 10 items
+
+User.find({ name: {$eq: 'Jane', $ignoreCase: true }});
+// In some cases you need to compare without taking into account case sensitive, for this you can use the $ ignoreCase property: true
+
 ```
 
 ```javascript

--- a/vuepress/guides/query-builder.md
+++ b/vuepress/guides/query-builder.md
@@ -31,6 +31,7 @@ const params = {
     $and: [
       { price2: { $gt: 1.99, $isNotNull: true } },
       { $or: [{ price3: { $gt: 1.99, $isNotNull: true } }, { id: '20' }] },
+      { name: { $eq: 'John', $ignoreCase: true } },
     ],
     $any: {
       $expr: [{ $in: { search_expr: 'search', target_expr: 'address' } }],
@@ -255,6 +256,12 @@ Available COLLECTION operators:
 | \$in        | IN        |
 | \$within    | WITHIN    |
 | \$satisfies | SATISFIES |
+
+Available String Modifiers:
+
+| key          | value   |
+| ------------ | ------- |
+| \$ignoreCase | Boolean |
 
 ## N1QL JOIN clause structure (Currently the JOIN clause is only supported in string format.)
 


### PR DESCRIPTION
How to use:

```ts
User.find({ name: {$eq: 'Jane', $ignoreCase: true }});
// In some cases you need to compare without taking into account case sensitive, for this you can use the $ignoreCase property: true

```