### PR TITLE
DOC-8129 update quick start guide

### DIFF
--- a/vuepress/guides/quick-start.md
+++ b/vuepress/guides/quick-start.md
@@ -19,7 +19,7 @@ If you still need to perform these tasks please use one of the following:
 ## Step 1: Create The Ottoman Node JS Project
 
 In this exercise, we will be working with the [Ottoman v2 ODM (Object Document Mapper)](https://github.com/couchbaselabs/node-ottoman)
-in conjunction with the [NodeJS SDK v3](https://docs.couchbase.com/nodejs-sdk/3.0/hello-world/start-using-sdk.html)
+in conjunction with the [NodeJS SDK v3](https://docs.couchbase.com/nodejs-sdk/current/hello-world/start-using-sdk.html)
 
 This tutorial was written using Node JS version 12.14, NPM version 6.13, and the Couchbase SDK 3.0, but higher version numbers should do.
 

--- a/vuepress/guides/quick-start.md
+++ b/vuepress/guides/quick-start.md
@@ -1,7 +1,7 @@
 # Quick Start with Ottoman v2
 
 >Before we get started with Ottoman and Node JS, we need to ensure you have Couchbase up and running.
->We will create a data bucket and two indexes for basic queries. Using Couchbase’s N1QL query syntax, 
+>We will create a data bucket and two indexes for basic queries. Using Couchbase’s N1QL query syntax,
 >we will create two indexes, a primary and adaptive index.
 >After we upsert our records, these indexes will allow us to look up our documents with the Query API in Ottoman
 
@@ -19,8 +19,11 @@ If you still need to perform these tasks please use one of the following:
 ## Step 1: Create The Ottoman Node JS Project
 
 In this exercise, we will be working with the [Ottoman v2 ODM (Object Document Mapper)](https://github.com/couchbaselabs/node-ottoman)
-in conjunction with the [NodeJS SDK v3](https://docs.couchbase.com/nodejs-sdk/3.0/hello-world/start-using-sdk.html) or any minor version that is higher will do.
-I’m using Node JS version 12.14 and NPM version 6.13, you can find these version numbers for Node and NPM by running the following command:
+in conjunction with the [NodeJS SDK v3](https://docs.couchbase.com/nodejs-sdk/3.0/hello-world/start-using-sdk.html)
+
+This tutorial was written using Node JS version 12.14, NPM version 6.13, and the Couchbase SDK 3.0, but higher version numbers should do.
+
+You can check your version numbers by running the following commands:
 
 
 ```bash
@@ -35,13 +38,10 @@ You can get to the Couchbase Server Web UI at any time by visiting [localhost:80
 Let’s first create a project directory named `first-query-ottoman`, change directories into that directory and initialize NPM:
 
 ```bash
-mkdir first-query-ottoman && cd $_ && npm init
+mkdir first-query-ottoman
+cd first-query-ottoman
+npm init
 ```
-
-::: tip Note
-The double ampersands (`&&`) are just a way of chaining multiple shell commands. 
-The `$_` command simply captures our last used argument which in our case was the directory that we created.
-:::
 
 Now with a node package manager and manifest (`package.json`) in place, let’s add Ottoman to our dependencies for the project:
 
@@ -52,10 +52,12 @@ npm install ottoman@alpha
 Now we will create a file named `server.js` and launch Visual Studio Code:
 
 ```bash
-touch server.js && code .
+touch server.js
+code .
 ```
 
-This command has set up a project directory and enabled npm, installed `ottoman` as well as created a `server.js` file and
+We have now set up a project directory and enabled npm, installed `ottoman`,
+created a `server.js` file and
 finally opened up our VS Code editor to the project root.
 
 Open `server.js` file, this is where we’ll add our code.
@@ -68,23 +70,23 @@ Taking each code sample below, we will add each new block of code done after one
 Create a connection to our Couchbase Server running in Docker. Your password may be different, just swap out yours if it is different.
 
 ```javascript
-const {connect} = require('ottoman');
+const ottoman = require('ottoman');
 
 connect({
     connectionString: 'couchbase://localhost',
     bucketName: 'default',
-    username: 'admin',
+    username: 'Administrator',
     password: 'password'
 });
 ```
 
 ## Creating an Ottoman Model
 
-Create a model for our `User` document. It will get auto-created and stored in our already created `default` bucket in Couchbase.
-Once our model is set up, we can add a few initial documents to populate our bucket.
+Create a model for our `User` document.
+This defines the expected structure of each document, and also which "Collection" Couchbase will store the documents in.
 
 ```javascript
-const User = model('User', {
+const User = ottoman.model('User', {
   firstName: String,
   lastName: String,
   email: String,
@@ -93,54 +95,52 @@ const User = model('User', {
 ```
 
 Ottoman does support other data types like `boolean`, `number`, and `Date`.
-A model can also define indexes similar to the ones we set up manually. 
-For now, we are going to skip letting Ottoman set up our indexes as we already have them in place.
+A model can also define indexes, but for now we will skip this,
+as we already set up indexes manually in the prerequisites.
 
 ## Create New User Documents
 
-Here we are defining a few documents that we want to persist to our bucket,
-notice we are using the same document that we defined in our model.
+Now we will define a few documents that we want to persist to our bucket.
+We are using the document structure that we defined in our model.
 
 ```javascript
 const perry = new User({
   firstName: 'Perry',
   lastName: 'Mason',
-  email: 'perry.mason@acme.com',
+  email: 'perry.mason@example.com',
   tagLine : 'Who can we get on the case?'
 })
 
 const tom = new User({
   firstName: 'Major',
   lastName: 'Tom',
-  email: 'major.tom@acme.com',
+  email: 'major.tom@example.com',
   tagLine : 'Send me up a drink'
 })
 ```
 
 ## Persist Documents to Our Bucket
 
-Let's create an `async` function called `runAsync` to handle our code with the `async/await` technique. 
-In the function body block just call Ottoman’s `save()` method on each of these objects which will add them to our database so long as no errors occur.
+So far we have simply defined model structure and created documents locally.
+
+Now that we want to persist the documents, all our interaction with the Couchbase server
+will be done asynchronously, so we will call Ottomonan's `save()` method on each
+object using the `async`/`await` technique.
 
 
 ```javascript
 const runAsync = async () => {
-    try {
-        await perry.save();
-        console.log(`success: user ${perry.firstName} added!`)
-    } catch (err) {
-        throw err;
-    }
+  await perry.save();
+  console.log(`success: user ${perry.firstName} added!`)
 
-    try {
-        await tom.save();
-        console.log(`success: user ${tom.firstName} added!`)
-    } catch (err) {
-        throw err;
-    }
+  await tom.save();
+  console.log(`success: user ${tom.firstName} added!`)
 }
 
-runAsync();
+ottoman.start()
+  .then(runAsync)
+  .catch((error) => console.log(error))
+  .finally(process.exit)
 ```
 
 Now that we have added the code to save (persist) each record to the database, let’s run our app for the first time with Node:
@@ -149,15 +149,17 @@ Now that we have added the code to save (persist) each record to the database, l
 node server.js
 ```
 
-You should get two success messages in the console.
+You should get success messages in the console.
+(Note that the collection creation will happen only the first time you run the code.)
 
 ```bash
+collection created: _default/User
 success: user Perry added!
 success: user Major added!
 ```
 
 If we open our Web UI at [localhost:8091](http://localhost:8091/) and navigate to the "Buckets" tab,
-we can see that two records were added to the `default` bucket.
+we can see that the `User` collection, and two records have been added to the `default` bucket.
 
 ::: tip Note
 You can edit the document in place by clicking the pencil icon or remove them individually with the trash icon.
@@ -176,39 +178,32 @@ Append the `find()` logic to our `runAsync` function.
 ```javascript
 runAsync = async () => {
   //...saving users
- 
-  try {
-    const result = await User.find({ lastName: 'Tom' }, { consistency: SearchConsistency.LOCAL })
-    console.log('Query Result: ', result.rows)
-  } catch (err) {
-    throw err;
-  }
+
+  const result = await User.find(
+    { lastName: 'Tom' },
+    { consistency: ottoman.SearchConsistency.LOCAL })
+  console.log('Query Result: ', result.rows)
 }
 ```
 
 The first two arguments to the `find()` method are `filter` and `options`.
 
-Instead of passing objects along as parameters, 
+Instead of passing objects along as parameters,
 let’s write our code to define the filter and options as objects first and then pass them into the function as arguments.
 
 
 ```javascript
 runAsync = async () => {
   //...saving users
- 
-  try {
-    const filter = { lastName: 'Tom' };
-    const options = { consistency: SearchConsistency.LOCAL };
-    const result = await User.find(filter, options)
-    console.log('Query Result: ', result.rows)
-  } catch (err) {
-    throw err;
-  }
+
+  const filter = { lastName: 'Tom' };
+  const options = { consistency: ottoman.SearchConsistency.LOCAL };
+  const result = await User.find(filter, options)
 }
 ```
 
 ::: tip Note
-If we had a lot more data and we were expecting hundreds of records to be returned, 
+If we had a lot more data and we were expecting hundreds of records to be returned,
 we could page the results with our options to get the second page (pagination), like this:
 :::
 
@@ -216,7 +211,7 @@ we could page the results with our options to get the second page (pagination), 
 const options = {
   limit: 10,
   skip: 10,
-  consistency: SearchConsistency.LOCAL
+  consistency: ottoman.SearchConsistency.LOCAL
 }
 ```
 
@@ -261,76 +256,69 @@ In our case indexes were added manually, if not Ottoman would have given us this
 
 ::: details Here you can see the complete content of the server.js file.
 ```javascript
-const {connect, model, SearchConsistency} = require('ottoman');
+const ottoman = require('ottoman');
 
-const connection = connect({
+ottoman.connect({
     connectionString: 'couchbase://localhost',
     bucketName: 'default',
-    username: 'admin',
+    username: 'Administrator',
     password: 'password'
 });
 
-const User = model('User', {
-    firstName: String,
-    lastName: String,
-    email: String,
-    tagline: String
-});
+const User = ottoman.model('User', {
+  firstName: String,
+  lastName: String,
+  email: String,
+  tagline: String
+})
 
 const perry = new User({
-    firstName: 'Perry',
-    lastName: 'Mason',
-    email: 'perry.mason@acme.com',
-    tagLine : 'Who can we get on the case?'
+  firstName: 'Perry',
+  lastName: 'Mason',
+  email: 'perry.mason@example.com',
+  tagLine : 'Who can we get on the case?'
 })
 
 const tom = new User({
-    firstName: 'Major',
-    lastName: 'Tom',
-    email: 'major.tom@acme.com',
-    tagLine : 'Send me up a drink'
+  firstName: 'Major',
+  lastName: 'Tom',
+  email: 'major.tom@example.com',
+  tagLine : 'Send me up a drink'
 })
 
 const runAsync = async () => {
-    try {
-        await perry.save();
-        console.log(`success: user ${perry.firstName} added!`)
-    } catch (err) {
-        throw err;
-    }
+  await perry.save();
+  console.log(`success: user ${perry.firstName} added!`)
 
-    try {
-        await tom.save();
-        console.log(`success: user ${tom.firstName} added!`)
-    } catch (err) {
-        throw err;
-    }
+  await tom.save();
+  console.log(`success: user ${tom.firstName} added!`)
 
-    try {
-        const filter = { lastName: 'Tom' };
-        const options = { consistency: SearchConsistency.LOCAL };
-        const result = await User.find(filter, options)
-        console.log('Query Result: ', result.rows)
-    } catch (err) {
-        throw err;
-    }
+  const filter = { lastName: 'Tom' };
+  const options = { consistency: ottoman.SearchConsistency.LOCAL };
+
+  const result = await User.find(filter, options)
+  console.log('Query Result: ', result.rows)
 }
 
-runAsync();
+ottoman.start()
+  .then(runAsync)
+  .catch((error) => console.log(error))
+  .finally(process.exit)
 ```
 :::
 
 ## Summary
-We have created models in Ottoman, defined some documents, and persisted them to the database. 
-We then subsequently looked them up using the built-in `find()` method which used the Ottoman Query API for Couchbase. 
+We have created models in Ottoman, defined some documents, and persisted them to the database.
+We then subsequently looked them up using the built-in `find()` method which used the Ottoman Query API for Couchbase.
 We have not yet touched on indexes other than the fact that we created two of them during the docker and indexes section of the quickstart.
 
-If you would like to continue learning about Ottoman, I suggest checking out the [Ottoman Documentation](http://ottomanjs.com/).
+If you would like to continue learning about Ottoman, we suggest checking out the [Ottoman Documentation](http://ottomanjs.com/).
 
 
 ## Exercise Complete
 
-Congratulations! You have engaged with the world’s most powerful JSON document database by using Ottoman. 
-Know that our query language N1QL was run under the hood too but we did not have to write any N1QL, 
-you can learn more about it with our [N1QL Tutorial](https://query-tutorial.couchbase.com/tutorial) 
+Congratulations! You have engaged with the world’s most powerful JSON document database by using Ottoman.
+
+Note that our query language N1QL was run under the hood too but we did not have to write any directly.
+You can learn more about it with our [N1QL Tutorial](https://query-tutorial.couchbase.com/tutorial)
 if you are interested in exploring our query language for Couchbase.


### PR DESCRIPTION
PR for quickstart guide. Please note this included rather more code verification and work than our initial remit (e.g "language polishing").

The functionality all looks solid btw! So would be good Dev team to do an additional pass to ensure all the pages and examples are technically correct/up-to-date before Docs team come in to do final polish?

---

Language tweaks, as requested.

But also:

	* Simplify bash instructions.
	* Fix unspecified imports.
	* Changed default user to "Administrator" (in line with usual Couchbase docs)
	* Use `example.com` as per https://tools.ietf.org/html/rfc2606
	* Fix and simplify async calling:
		- add missing `ottoman.start()` call
		- move error handling to outer caller, where it gets invoked
		  instead of hiding messages
		- add process.exit, to ensure the script terminates
	* Mention collection creation.
	(NB: Removed a section earlier, which was confusing - the creation of
	collection doesn’t happen on definition of the model, only when running within
	`ottoman.start()`)