### PR TITLE
feat(schema): add timestamps as schema option

### DIFF
--- a/__test__/let-clause.spec.ts
+++ b/__test__/let-clause.spec.ts
@@ -33,7 +33,7 @@ describe('LET clause', () => {
     const ottoman = getDefaultInstance();
     await startInTest(ottoman);
 
-    const response = await ottoman.query(query);
+    const response = await ottoman.query(query, { scanConsistency: 'request_plus' });
 
     expect(response.rows).toStrictEqual([
       {

--- a/__test__/schema-timestamps.spec.ts
+++ b/__test__/schema-timestamps.spec.ts
@@ -1,0 +1,75 @@
+import { getDefaultInstance, model, Schema } from '../src';
+import { delay, startInTest } from './testData';
+
+describe(`Schema timestamps options`, () => {
+  test('timestamps set to true', async () => {
+    const schema = new Schema({ title: String }, { timestamps: true });
+    const Travel = model('Travel', schema);
+    startInTest(getDefaultInstance());
+    const travelLA = await Travel.create({ title: 'go to LA' });
+    expect(travelLA.createdAt).toBeDefined();
+    expect(travelLA.updatedAt).toBeDefined();
+  });
+
+  test('timestamps set createdAt to true and updatedAt to false', async () => {
+    const schema = new Schema({ title: String }, { timestamps: { createdAt: true, updatedAt: false } });
+    const Travel = model('Travel', schema);
+    startInTest(getDefaultInstance());
+    const travelCA = await Travel.create({ title: 'go to CA' });
+    expect(travelCA.createdAt).toBeDefined();
+    expect(travelCA.updatedAt).toBeUndefined();
+  });
+
+  test('timestamps change key createdAt and updatedAt', async () => {
+    const schema = new Schema(
+      { title: String },
+      { timestamps: { createdAt: 'dateCreated', updatedAt: 'dateUpdated' } },
+    );
+    const Travel = model('Travel', schema);
+    startInTest(getDefaultInstance());
+    const travelDC = await Travel.create({ title: 'go to Washington DC' });
+    expect(travelDC['dateCreated']).toBeDefined();
+    expect(travelDC['dateUpdated']).toBeDefined();
+  });
+
+  test('timestamps test updateAt after update document', async () => {
+    const schema = new Schema({ title: String }, { timestamps: true });
+    const Travel = model('Travel', schema);
+    startInTest(getDefaultInstance());
+    const travelFL = await Travel.create({ title: 'go to FL' });
+    expect(travelFL.updatedAt).toBeDefined();
+    await delay(3000);
+    travelFL.title = 'go to FL Updated';
+    await travelFL.save();
+    expect(travelFL.updatedAt).toBeDefined();
+  });
+
+  test('timestamps test currentTime', async () => {
+    const schema = new Schema(
+      { title: String, createdAt: Number, updatedAt: Number },
+      { timestamps: { currentTime: () => Math.floor(Date.now() / 1000) } },
+    );
+    const Travel = model('Travel', schema);
+    startInTest(getDefaultInstance());
+    const travelCH = await Travel.create({ title: 'go to CH' });
+    expect(travelCH.createdAt).toBeDefined();
+    expect(travelCH.updatedAt).toBeDefined();
+  });
+
+  test('timestamps test currentTime with update', async () => {
+    const schema = new Schema(
+      { title: String, createdAt: Number, updatedAt: Number },
+      { timestamps: { currentTime: () => Math.floor(Date.now() / 1000) } },
+    );
+    const Travel = model('Travel', schema);
+    startInTest(getDefaultInstance());
+    const travelCH = await Travel.create({ title: 'go to CH' });
+    expect(typeof travelCH.createdAt).toBe('number');
+    expect(typeof travelCH.updatedAt).toBe('number');
+    await delay(5000);
+    travelCH.title = 'go to CH Updated';
+    await travelCH.save();
+    expect(travelCH.updatedAt).toBeDefined();
+    expect(typeof travelCH.updatedAt).toBe('number');
+  });
+});

--- a/src/model/index/n1ql/ensure-n1ql-indexes.ts
+++ b/src/model/index/n1ql/ensure-n1ql-indexes.ts
@@ -86,6 +86,14 @@ export const ensureN1qlIndexes = async (ottoman: Ottoman, n1qlIndexes) => {
     }
   }
 
+  if (ottoman.onIndexReady) {
+    let names: string[] = [];
+    for (const key in indexesToBuild) {
+      names = [...names, ...(indexesToBuild[key] || [])];
+    }
+    ottoman.queryIndexManager.watchIndexes(bucketName, names, 300000, {}, ottoman.onIndexReady);
+  }
+
   // All indexes were built deferred, so now kick off the actual build.
   for (const key in indexesToBuild) {
     const buildIndexes = indexesToBuild[key];

--- a/src/ottoman/ottoman.ts
+++ b/src/ottoman/ottoman.ts
@@ -46,6 +46,45 @@ interface OttomanConfig {
   keyGeneratorDelimiter?: string;
 }
 
+interface queryOptions {
+  /** Specifies whether this is an ad-hoc query, or if it should be prepared for faster execution in the future. **/
+  adhoc?: boolean;
+  /** The returned client context id for this query. **/
+  clientContextId?: string;
+  /** Specifies a MutationState which the query should be consistent with. **/
+  consistentWith?: any;
+  /** Specifies whether flex-indexes should be enabled. Allowing the use of full-text search from the query service. **/
+  flexIndex?: boolean;
+  /** This is an advanced option, see the query service reference for more information on the proper use and tuning of this option. **/
+  maxParallelism?: number;
+  /** Specifies whether metrics should be captured as part of the execution of the query. **/
+  metrics?: boolean;
+  /** Values to be used for the placeholders within the query. **/
+  parameters?: any[] | any;
+  /** The parent tracing span that this operation will be part of. **/
+  parentSpan?: { addTag(key: string, value: string | number | boolean): void; end(): void };
+  /** This is an advanced option, see the query service reference for more information on the proper use and tuning of this option. **/
+  pipelineBatch?: number;
+  /** This is an advanced option, see the query service reference for more information on the proper use and tuning of this option. **/
+  pipelineCap?: number;
+  /** Specifies the level of profiling that should be used for the query. **/
+  profile?: 'off' | 'phases' | 'timings';
+  /** Specifies the context within which this query should be executed. This can be scoped to a scope or a collection within the dataset. **/
+  queryContext?: string;
+  /** Specifies any additional parameters which should be passed to the query engine when executing the query. **/
+  raw?: Record<string, any>;
+  /** Specifies that this query should be executed in read-only mode, disabling the ability for the query to make any changes to the data. **/
+  readOnly?: boolean;
+  /** This is an advanced option, see the query service reference for more information on the proper use and tuning of this option. **/
+  scanCap?: number;
+  /** Specifies the consistency requirements when executing the query. **/
+  scanConsistency?: 'not_bounded' | 'request_plus';
+  /** This is an advanced option, see the query service reference for more information on the proper use and tuning of this option. **/
+  scanWait?: number;
+  /** The timeout for this operation, represented in milliseconds. **/
+  timeout?: number;
+}
+
 /**
  * CertificateAuthenticator provides an authenticator implementation using TLS Cert Authentication.
  */
@@ -68,6 +107,7 @@ export class Ottoman {
   private n1qlIndexes: Record<string, { fields: string[]; modelName: string }> = {};
   private viewIndexes: Record<string, { views: { map?: string } }> = {};
   private refdocIndexes: Record<string, { fields: string[] }[]> = {};
+  public onIndexReady?: () => void;
 
   /**
    * @ignore
@@ -348,8 +388,8 @@ export class Ottoman {
    * WHERE (address LIKE '%57-59%' OR free_breakfast = true)
    * ```
    */
-  async query(query: string) {
-    return this.cluster.query(query);
+  async query(query: string, options: queryOptions = {}) {
+    return this.cluster.query(query, options);
   }
 
   /**

--- a/src/schema/interfaces/schema.types.ts
+++ b/src/schema/interfaces/schema.types.ts
@@ -31,6 +31,12 @@ export interface RequiredOption {
   message: string;
 }
 
+interface SchemaTimestampsConfig {
+  createdAt?: boolean | string;
+  updatedAt?: boolean | string;
+  currentTime?: () => Date | number;
+}
+
 export interface CoreTypeOptions {
   required?: boolean | RequiredOption | RequiredFunction;
   /**
@@ -51,4 +57,10 @@ export interface SchemaOptions {
   strict?: boolean;
   preHooks?: Hook;
   postHooks?: Hook;
+  /**
+   * The timestamps option tells Ottoman to assign createdAt and updatedAt fields to your schema. The type
+   * assigned is `Date`. By default, the names of the fields are createdAt and updatedAt. Customize the
+   * field names by setting timestamps.createdAt and timestamps.updatedAt.
+   */
+  timestamps?: boolean | SchemaTimestampsConfig;
 }

--- a/vuepress/guides/schema.md
+++ b/vuepress/guides/schema.md
@@ -54,6 +54,60 @@ The meta above cannot have its own validation as a side-effect of this. If valid
 Schemas not only define the structure of your document and casting of properties, they also define document [instance methods](#instance-methods), [static Model methods](#statics),
 [compound indexes](#indexes), [plugins](#plugins), and document lifecycle [hooks](#hooks).
 
+## Schema Options
+
+Schemas have a few configurable options which can be passed to the constructor:
+
+```typescript
+new Schema({...}, options);
+```
+
+The availables options are:
+```typescript
+export interface SchemaOptions {
+  strict?: boolean;
+  preHooks?: Hook;
+  postHooks?: Hook;
+  timestamps?: boolean | SchemaTimestampsConfig;
+}
+```
+
+### Option Timestamps
+
+The timestamps option tells `Ottoman` to assign `createdAt` and `updatedAt` fields to your schema. The type assigned is `Date`.
+
+By default, the names of the fields are `createdAt` and `updatedAt`. Customize the field names by setting `timestamps.createdAt` and `timestamps.updatedAt`.
+
+Basic example:
+```typescript
+const travelSchema = new Schema({..}, { timestamps: true });
+const Travel = model('Travel', thingSchema);
+const travel = new Travel();
+await travel.save(); // `createdAt` & `updatedAt` will be included
+```
+
+Customize `createdAt` to `created_at`
+```typescript
+const travelSchema = new Schema({..}, { timestamps: { createdAt: 'created_at' } });
+const Travel = model('Travel', thingSchema);
+const travel = new Travel();
+await travel.save(); // `created_at` & `updatedAt` will be included
+```
+
+By default, Ottoman uses `new Date()` to get the current time. If you want to overwrite the function Ottoman uses to get the current time, you can set the `timestamps.currentTime` option.
+Ottoman will call the `timestamps.currentTime` function whenever it needs to get the current time.
+
+```typescript
+const schema = Schema({
+  createdAt: Number,
+  updatedAt: Number,
+  name: String
+}, {
+  // Make Ottoman use Unix time (seconds since Jan 1, 1970)
+  timestamps: { currentTime: () => Math.floor(Date.now() / 1000) }
+});
+```
+
 ## Creating a Model
 
 To use our schema definition, we need to convert our `blogSchema` into a [Model](/guides/model.html) we can work with. To do so, we pass it into `model(modelName, schema)`:
@@ -117,6 +171,7 @@ let animals = await Animal.findByName('fido');
 ::: danger Note
 Do **not** declare _statics_ using ES6 arrow functions (`=>`). Arrow functions [explicitly prevent binding](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Functions/Arrow_functions) `this`, so the above examples will **not** work because of the value of `this`.
 :::
+
 
 ## Indexes
 
@@ -245,6 +300,13 @@ console.log(usersN1ql.rows);
   }
 ]
 ```
+
+:::warning Not Recommended
+`ensureIndex` is nice for development, but it's recommended this behavior be disabled in production since index creation can cause a significant performance impact.
+Disable the behavior by don't execute `ensureIndex` function. (for example you can use node env variable to know when you are in development mode [process.ENV.development])
+
+Notice: the `start` function should be disabled too, due to it use `ensureIndexes` internally.
+:::
 
 ### RefDoc
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -3551,10 +3551,17 @@ debug@^3.1.1, debug@^3.2.5:
   dependencies:
     ms "^2.1.1"
 
-debug@^4.0.1, debug@^4.1.0, debug@^4.1.1, debug@^4.2.0, debug@^4.3.1:
+debug@^4.0.1, debug@^4.1.0, debug@^4.1.1, debug@^4.2.0:
   version "4.3.1"
   resolved "https://registry.yarnpkg.com/debug/-/debug-4.3.1.tgz#f0d229c505e0c6d8c49ac553d1b13dc183f6b2ee"
   integrity sha512-doEwdvm4PCeK4K3RQN2ZC2BYUBaxwLARCqZmMjtF8a51J2Rb0xpVloFRnCODwqjpwnAoao4pelN8l3RJdv3gRQ==
+  dependencies:
+    ms "2.1.2"
+
+debug@^4.3.1:
+  version "4.3.2"
+  resolved "https://registry.yarnpkg.com/debug/-/debug-4.3.2.tgz#f0a49c18ac8779e31d4a0c6029dfb76873c7428b"
+  integrity sha512-mOp8wKcvj7XxC78zLgw/ZA+6TSgkoE2C/ienthhRD298T7UNwAg9diBpLRxC0mOezLl4B0xV7M0cCO6P/O0Xhw==
   dependencies:
     ms "2.1.2"
 
@@ -7458,10 +7465,15 @@ object-copy@^0.1.0:
     define-property "^0.2.5"
     kind-of "^3.0.3"
 
-object-inspect@^1.8.0, object-inspect@^1.9.0:
+object-inspect@^1.8.0:
   version "1.9.0"
   resolved "https://registry.yarnpkg.com/object-inspect/-/object-inspect-1.9.0.tgz#c90521d74e1127b67266ded3394ad6116986533a"
   integrity sha512-i3Bp9iTqwhaLZBxGkRfo5ZbE07BQRT7MGu8+nNgwW9ItGp1TzCTw2DLEoWwjClxBjOFI/hWljTAmYGCEwmtnOw==
+
+object-inspect@^1.9.0:
+  version "1.11.0"
+  resolved "https://registry.yarnpkg.com/object-inspect/-/object-inspect-1.11.0.tgz#9dceb146cedd4148a0d9e51ab88d34cf509922b1"
+  integrity sha512-jp7ikS6Sd3GxQfZJPyH3cjcbJF6GZPClgdV+EFygjFLQ5FmW/dRUnTd9PQ9k0JhoNDabWFbpF1yCdSWCC6gexg==
 
 object-is@^1.0.1:
   version "1.1.4"


### PR DESCRIPTION
adding timestamps as schema option. Also add onIndexCreation event hook to know when all the indexes
were created and ready to use. queryOptions was added for cluster.query method

"feat #531", "feat #532", "feat #542"