### PR TITLE
Fixes Issue #610

### DIFF
--- a/__test__/ensure_collections_and_indexes.spec.ts
+++ b/__test__/ensure_collections_and_indexes.spec.ts
@@ -1,0 +1,129 @@
+/* eslint-disable prettier/prettier */
+import { getDefaultInstance, model, ModelTypes, Ottoman, Schema, StringType } from '../src';
+import { DurabilityLevel, BucketType, CompressionMode, EvictionPolicy, ConflictResolutionType } from 'couchbase';
+import { connectionString, password, username, delay, consistency } from './testData';
+
+const connOptions = { connectionString, username, password, bucketName: 'testBucket' };
+
+const UserSchema = new Schema(
+  {
+    userid: { type: String, required: true },
+    firstName: String,
+    lastName: String,
+    username: String,
+    street: String,
+    city: String,
+    state: String,
+    zipCode: Number,
+    name: String,
+    phone: String,
+    email: String,
+  },
+  {
+    timestamps: true,
+  },
+);
+
+model('UserProfile', UserSchema, {
+  idKey: 'userid',
+  collectionName: 'UserProfileCollectionTest',
+  scopeName: 'UserProfileScopeTest',
+});
+
+describe('Testing ensure collections and indexes', () => {
+  test('Create a new bucket', async () => {
+    const otto = getDefaultInstance();
+
+    await otto.cluster.buckets().createBucket({
+      conflictResolutionType: ConflictResolutionType.SequenceNumber,
+      ejectionMethod: EvictionPolicy.ValueOnly,
+      name: 'testBucket',
+      flushEnabled: false,
+      ramQuotaMB: 200,
+      numReplicas: 1,
+      replicaIndexes: false,
+      bucketType: BucketType.Couchbase,
+      evictionPolicy: EvictionPolicy.ValueOnly,
+      maxExpiry: 0,
+      compressionMode: CompressionMode.Passive,
+      minimumDurabilityLevel: DurabilityLevel.None,
+      maxTTL: 0,
+      durabilityMinLevel: 'none',
+    });
+    await delay(2500);
+
+    const newOtto = new Ottoman(consistency);
+    const testBucket = await newOtto.connect(connOptions);
+    expect(testBucket).toBeDefined();
+    testBucket.close();
+  });
+  test('Ensure Collections and Indexes (ABUSIVE METHOD)', async () => {
+    const newOtto = new Ottoman(consistency);
+    const testBucket = await newOtto.connect(connOptions);
+    const UserModels: ModelTypes[] = [];
+    expect.assertions(5);
+
+    for (let i = 0; i < 5; i++) {
+      UserModels[i] = testBucket.model('User' + i, UserSchema, { scopeName: 'Test' + i, collectionName: 'Test' + i });
+      await testBucket.start();
+      const newUser = new UserModels[i]({ userid: 'test' + i, firstName: 'Test' + i });
+      await newUser.save();
+      const results = (await UserModels[i].find({ firstName: 'Test' + i })).meta.status as string;
+      expect(results).toBe('success');
+    }
+
+    testBucket.close();
+  });
+
+  test('Ensure Collections and Indexes (NORMAL METHOD)', async () => {
+    const newOtto = new Ottoman(consistency);
+    const testBucket = await newOtto.connect(connOptions);
+    const UserModels: ModelTypes[] = [];
+    expect.assertions(5);
+
+    for (let i = 5; i < 10; i++) {
+      UserModels[i] = testBucket.model('User' + i, UserSchema, { scopeName: 'Test' + i, collectionName: 'Test' + i });
+    }
+    await testBucket.start();
+
+    for (let i = 5; i < 10; i++) {
+      const newUser = new UserModels[i]({ userid: 'test' + i, firstName: 'Test' + i });
+      await newUser.save();
+      const results = (await UserModels[i].find({ firstName: 'Test' + i })).meta.status as string;
+      expect(results).toBe('success');
+    }
+
+    testBucket.close();
+  });
+  test('Drop Collections', async () => {
+    const newOtto = new Ottoman(consistency);
+    const testBucket = await newOtto.connect(connOptions);
+
+    expect.assertions(10);
+
+    for (let i = 0; i < 10; i++) {
+      const results = await testBucket.dropCollection('Test' + i, 'Test' + i);
+      expect(results).toBeUndefined();
+    }
+    testBucket.close();
+  });
+
+  test('Drop Scope', async () => {
+    const newOtto = new Ottoman(consistency);
+    const testBucket = await newOtto.connect(connOptions);
+
+    expect.assertions(10);
+
+    for (let i = 0; i < 10; i++) {
+      const results = await testBucket.dropScope('Test' + i);
+      expect(results).toBeUndefined();
+    }
+    testBucket.close();
+  });
+
+  test('Drop Bucket', async () => {
+    const otto = getDefaultInstance();
+    const test = await otto.dropBucket('testBucket');
+    expect(test).toBeUndefined();
+  });
+});

--- a/src/model/index/n1ql/ensure-n1ql-indexes.ts
+++ b/src/model/index/n1ql/ensure-n1ql-indexes.ts
@@ -92,13 +92,17 @@ export const ensureN1qlIndexes = async (ottoman: Ottoman, n1qlIndexes) => {
     }
   }
 
+  let names: string[] = [];
+  for (const key in indexesToBuild) {
+    names = [...names, ...(indexesToBuild[key] || [])];
+  }
+
+  ottoman.indexOnlinePromise = ottoman.queryIndexManager.watchIndexes(bucketName, names, 600000, {
+    watchPrimary: false,
+  });
+
   if (ottoman.indexReadyHooks && ottoman.indexReadyHooks.length > 0) {
-    let names: string[] = [];
-    for (const key in indexesToBuild) {
-      names = [...names, ...(indexesToBuild[key] || [])];
-    }
-    ottoman.indexOnlinePromise = ottoman.queryIndexManager
-      .watchIndexes(bucketName, names, 600000, { watchPrimary: false })
+    ottoman.indexOnlinePromise
       .then(() => {
         ottoman.indexOnline = true;
         ottoman.indexReadyHooks.forEach((fn) => fn(null, ottoman));

--- a/src/ottoman/ottoman.ts
+++ b/src/ottoman/ottoman.ts
@@ -508,17 +508,17 @@ const tryCreateCollection = async (
   delayMS = 5000,
 ) => {
   let collectionDoesNotExists = true;
-  let testDelay = 0;
-  let testCount = 0;
-  while (collectionDoesNotExists && testCount < retries + 1) {
-    await delay(testDelay);
+  let tryDelay = 0;
+  let tryCount = 0;
+  while (collectionDoesNotExists && tryCount < retries + 1) {
+    await delay(tryDelay);
     try {
       await createCollection({ collectionManager, collectionName, scopeName, maxExpiry });
     } catch (e) {
       if (e instanceof (couchbase as any).CollectionExistsError) collectionDoesNotExists = false;
     }
-    testDelay += Math.max(Math.min(testDelay * 10, delayMS), 100);
-    testCount++;
+    tryDelay += Math.max(Math.min(tryDelay * 10, delayMS), 100);
+    tryCount++;
   }
 };
 

--- a/src/ottoman/ottoman.ts
+++ b/src/ottoman/ottoman.ts
@@ -509,7 +509,7 @@ const tryCreateCollection = async (
 ) => {
   let collectionDoesNotExists = true;
   let testDelay = 0;
-  let testCount = 1;
+  let testCount = 0;
   while (collectionDoesNotExists && testCount < retries + 1) {
     await delay(testDelay);
     try {

--- a/src/ottoman/ottoman.ts
+++ b/src/ottoman/ottoman.ts
@@ -508,6 +508,7 @@ const tryCreateCollection = async (
   delayMS = 5000,
 ) => {
   let collectionDoesNotExists = true;
+  let err = null;
   let tryDelay = 0;
   let tryCount = 0;
   while (collectionDoesNotExists && tryCount < retries + 1) {
@@ -516,10 +517,12 @@ const tryCreateCollection = async (
       await createCollection({ collectionManager, collectionName, scopeName, maxExpiry });
     } catch (e) {
       if (e instanceof (couchbase as any).CollectionExistsError) collectionDoesNotExists = false;
+      err = e;
     }
     tryDelay += Math.max(Math.min(tryDelay * 10, delayMS), 100);
     tryCount++;
   }
+  if (collectionDoesNotExists && err) throw new Error(err);
 };
 
 export const getDefaultInstance = () => __ottoman;


### PR DESCRIPTION
This pull request fixes issue #610 as well as passes all legacy and non legacy tests (without the `OTTOMAN_LEGACY_TEST=1` set).  

Intermittently there would be `LCB_ERR_KEYSPACE_NOT_FOUND` when creating new collections and indexes.  This would happen because sometimes the `ensureCollections` would return before the collections were actually ready.  Additionally sometimes there would be Query `Planning Failures` when running on freshly created models because the `ensureIndexes` would not return the `indexOnlinePromise` unless `indexReadyHooks` were defined.

The changes in this pull request refactor some logic in the `ensureCollections` and `ensureIndexes` functions.  It now guarantees that the collections and the indexes will be ready as described in the documentation.