### PR TITLE
chore(version): bump Ottoman version to 2.3.0 for release

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "ottoman",
-  "version": "2.2.2",
+  "version": "2.3.0",
   "main": "lib/index.js",
   "types": "lib/types/index.d.ts",
   "description": "Ottoman Couchbase ODM",


### PR DESCRIPTION
Release notes: 

### Fixed Issues
* Bumps `couchbase` dependency to 4.2.0

### ***PLEASE READ:*** Important Configuration Change
* This release includes a **major version bump** to the Couchbase dependency, and with it a specific change to handling SSL/TLS connections:
    * If you were previously skipping certificate checking with the parameter `?ssl=no_verify` in your connection string, you'll need to update it to `?tls_verify=none`
    * More information can be found in [this article](https://developer.couchbase.com/tutorial-nodejs-tls-connection#tls-authentication-without-certificate-checking)


**Full Changelog**: https://github.com/couchbaselabs/node-ottoman/compare/v2.2.2...v2.3.0