### PR TITLE
fix(DateType.cast): preserve null/undefined values instead of casting to unix timestamp

### DIFF
--- a/src/schema/types/date-type.ts
+++ b/src/schema/types/date-type.ts
@@ -67,11 +67,15 @@ export class DateType extends CoreType {
   }
 
   cast(value: any, strategy = CAST_STRATEGY.DEFAULT_OR_DROP) {
+    if(value === null || value === undefined) {
+      return value;
+    }
+    
     if (isDateValid(value)) {
       return new Date(value);
-    } else {
-      return checkCastStrategy(value, strategy, this);
-    }
+    } 
+    
+    return checkCastStrategy(value, strategy, this);
   }
 
   validate(value: unknown, strategy) {


### PR DESCRIPTION
**Problem**

Currently, when a schema field is defined as Date and the stored database value of this field is null, DateType Class casts the value a JavaScript Date object representing the Unix epoch (1970-01-01T00:00:00Z).

This behavior causes unintended side effects:

- null values are misrepresented as a valid date.
- Application logic may misinterpret 1970-01-01 as meaningful rather than "no value".

Example:

```
const doc = await Model.findById(someId);
console.log(doc.dateField); 
// Current behavior → Date("1970-01-01T01:00:00.000Z")
// Expected behavior → null
```

**Proposed Change**

Update the DateType.cast() method to return null or undefined as-is, instead of coercing to a Date.

**Benefits**

- Data integrity: Keeps null values intact, preserving the intent of the stored data.
- Predictability: Matches developer expectations when dealing with optional date fields.
- Backward-compatible: Existing behavior for valid/invalid values remains unchanged.
